### PR TITLE
Upgrade to Sphinx-Needs 8.x and classify new schema/link features

### DIFF
--- a/analysis/qualification.rst
+++ b/analysis/qualification.rst
@@ -16,8 +16,8 @@ Overall Features: :need_count:`type=="feature"`
    - * Metric
      * Measurement
      * Target
-   - * Safety Features without Errors
-     * :need_count:`type == "feature" and si == "yes" and len(parent_needs_back) == 0` 
+   - * Safety Features without Faults
+     * :need_count:`type == "feature" and si == "yes" and len(parent_needs_back) == 0`
      * 0
    - * Features without Safety Impact value
      * :need_count:`type == "feature" and si == "" and len(parent_needs_back) == 0`
@@ -26,7 +26,7 @@ Overall Features: :need_count:`type=="feature"`
      * :need_count:`type == "feature" and len(features_back) == 0`
      * \-
 
-.. dropdown:: Features without Errors
+.. dropdown:: Features without Faults
 
    .. needtable::
       :columns: id, title, tools
@@ -44,9 +44,9 @@ Overall Features: :need_count:`type=="feature"`
       :columns: id, title, si, tools
       :filter: type == "feature" and len(features_back) == 0
 
-Errors
+Faults
 ------
-Overall Errors: :need_count:`type=="fault"`
+Overall Faults: :need_count:`type=="fault"`
 
 .. list-table::
    :align: center
@@ -57,11 +57,11 @@ Overall Errors: :need_count:`type=="fault"`
    - * Metric
      * Measurement
      * Target
-   - * Errors without Mitigation
+   - * Faults without Mitigation
      * :need_count:`type == "fault" and len(avoids_back) == 0`
      * 0
 
-.. dropdown:: Errors without Mitigation
+.. dropdown:: Faults without Mitigation
 
    .. needtable::
       :columns: id, title, parent_needs
@@ -80,11 +80,11 @@ Overall Restrictions: :need_count:`type=="restriction"`
    - * Metric
      * Measurement
      * Target
-   - * Restrictions without Error
+   - * Restrictions without Fault
      * :need_count:`type == "restriction" and len(avoids) == 0`
      * 0
 
-.. dropdown:: Restrictions without Error
+.. dropdown:: Restrictions without Fault
 
    .. needtable::
       :columns: id, title, docname

--- a/index.rst
+++ b/index.rst
@@ -49,7 +49,7 @@ Introduction
 
 This documentation provides the necessary information to achieve
 "qualification readiness" for any Sphinx-based project. It includes ``use cases``,
-``features``, ``errors``, and ``restrictions`` represented as `Sphinx-Needs <https://sphinx-needs.com>`__
+``features``, ``faults``, and ``restrictions`` represented as `Sphinx-Needs <https://sphinx-needs.com>`__
 objects.
 
 The classification serves as the foundation for any qualification

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = [
     { name = "Daniel Woste", email = "daniel.woste@useblocks.com" }
 ]
 dependencies = [
-    "sphinx[test]>=8.2.3",
-    "sphinx-needs[plotting]>=6.1.0",
+    "sphinx[test]>=8.2.3,<10",
+    "sphinx-needs[plotting]>=8.0.0,<9",
     "sphinxcontrib-plantuml>=0.30",
     "sphinx-design>=0.6.1",
     "sphinx-simplepdf>=1.6.0",

--- a/tools/sphinx-codelinks/features.rst
+++ b/tools/sphinx-codelinks/features.rst
@@ -5,7 +5,7 @@ Features
 
    .. needtable::
       :filter: "tools/sphinx-codelinks/" in docname and type == "feature"
-      :columns: id, title, si as "SI", parent_needs_back as "Errors"
+      :columns: id, title, si as "SI", parent_needs_back as "Faults"
 
    .. needpie:: Sphinx-CodeLinks features
       :legend:

--- a/tools/sphinx-codelinks/main.rst
+++ b/tools/sphinx-codelinks/main.rst
@@ -26,7 +26,7 @@ Analysis
 
 .. needpie:: Sphinx-CodeLinks objects
    :legend:
-   :labels: Features, Errors, Restrictions, Checks, Steps
+   :labels: Features, Faults, Restrictions, Checks, Steps
    :explode: 0,0,0,0.1,0.1
 
    type == "feature" and "tools/sphinx-codelinks/" in docname
@@ -37,14 +37,14 @@ Analysis
 
 .. dropdown:: ✅ Compliance statistics
 
-   Features without errors: :need_count:`"tools/sphinx-codelinks/" in docname and type == "feature" and len(parent_needs_back) == 0`
+   Features without faults: :need_count:`"tools/sphinx-codelinks/" in docname and type == "feature" and len(parent_needs_back) == 0`
    / :need_count:`"tools/sphinx-codelinks/" in docname and type == "feature"`
 
-   Errors without a mitigation: :need_count:`"tools/sphinx-codelinks/" in docname and type == "fault" and (len(avoids_back) == 0 and len(checks_back) == 0)`
+   Faults without a mitigation: :need_count:`"tools/sphinx-codelinks/" in docname and type == "fault" and (len(avoids_back) == 0 and len(checks_back) == 0)`
    / :need_count:`"tools/sphinx-codelinks/" in docname and type == "fault"`
 
-   Restrictions without error: :need_count:`"tools/sphinx-codelinks/" in docname and type == "restriction" and len(avoids) == 0`
+   Restrictions without fault: :need_count:`"tools/sphinx-codelinks/" in docname and type == "restriction" and len(avoids) == 0`
    / :need_count:`"tools/sphinx-codelinks/" in docname and type == "restriction"`
 
-   Checks without error: :need_count:`"tools/sphinx-codelinks/" in docname and type == "check" and len(checks) == 0`
+   Checks without fault: :need_count:`"tools/sphinx-codelinks/" in docname and type == "check" and len(checks) == 0`
    / :need_count:`"tools/sphinx-codelinks/" in docname and type == "check"`

--- a/tools/sphinx-needs/features.rst
+++ b/tools/sphinx-needs/features.rst
@@ -5,7 +5,7 @@ Features
 
    .. needtable::
       :filter: "tools/sphinx-needs/" in docname and type == "feature"
-      :columns: id, title, si as "SI", parent_needs_back as "Errors"
+      :columns: id, title, si as "SI", parent_needs_back as "Faults"
 
    .. needpie:: Sphinx-Needs features
       :legend:

--- a/tools/sphinx-needs/features.rst
+++ b/tools/sphinx-needs/features.rst
@@ -243,19 +243,31 @@ Core Need Object
           dict(directive="test", title,"Test Case", prefix="T_", color="#DCFED2"),
       ]
 
-.. feature:: Customizable need options
+.. feature:: Customizable need fields
    :id: FE_SPHINX_NEEDS_CUSTOMIZABLE_OPTIONS
    :tools: TOOL_SN
    :si: yes
 
-   Define extra options that any need object can have, such as 'author'
-   or 'component'. These custom options can be displayed in tables and
-   used for filtering.
+   Define extra fields that any need object can have, such as ``author``
+   or ``component``. Custom fields can be displayed in tables, used for
+   filtering, and (since Sphinx-Needs 7) validated by an attached JSON
+   Schema.
 
-   .. code-block:: python
+   The legacy list-style ``needs_extra_options`` configuration is
+   deprecated; declarative ``needs_fields`` (``[needs.fields.<name>]``
+   in ``ubproject.toml``) is the supported form.
 
-      # In conf.py
-      needs_extra_options = ['author', 'component']
+   .. code-block:: toml
+
+      # In ubproject.toml
+      [needs.fields.author]
+      description = "Author of the need"
+      schema.type = "string"
+
+      [needs.fields.component]
+      description = "Logical sub-system the need belongs to"
+      schema.type = "string"
+      schema.enum = ["UI", "Backend", "Database"]
 
    .. code-block:: rst
 
@@ -264,23 +276,25 @@ Core Need Object
          :author: John Doe
          :component: UI
 
-   .. fault:: Invalid option used in a need
+   .. fault:: Invalid field used in a need
       :id: ER_SN_INVALID_OPTION
 
-      If an option is not defined in the configuration, Sphinx-Needs will
-      raise an error during the build process.
+      A field that is not defined in ``needs_fields`` is used in a
+      directive. Sphinx-Needs raises a warning during the build.
 
-   .. fault:: Option value is not valid
+   .. fault:: Field value does not match declared schema
       :id: ER_SN_INVALID_OPTION_VALUE
 
-      If an option value does not match the expected format or type, Sphinx-Needs
-      will raise an error during the build process.
+      A field value does not match the declared ``schema.type``,
+      ``schema.enum``, ``schema.minimum`` / ``maximum`` or ``schema.pattern``.
+      Sphinx-Needs emits a ``sn_schema_violation`` during the build.
 
-   .. fault:: Option value is not allowed
+   .. fault:: Field value is not allowed
       :id: ER_SN_OPTION_NOT_ALLOWED
 
-      If an option value is not allowed by the configuration, Sphinx-Needs will
-      raise an error during the build process.
+      A field value is not part of the allowed ``schema.enum`` list.
+      Without schema validation the wrong value silently reaches the
+      exported ``needs.json`` and downstream analysis.
 
 .. feature:: Customizable link types
    :id: FE_SPHINX_NEEDS_CUSTOMIZABLE_LINKS
@@ -288,35 +302,38 @@ Core Need Object
    :si: yes
 
    Define different types of links between needs to represent various
-   relationships. This helps to create a precise traceability model.
+   relationships. This is the foundation of a precise traceability
+   model.
 
-   .. code-block:: python
+   The legacy ``needs_extra_links`` list form is deprecated since
+   Sphinx-Needs 7; link types are declared as ``needs_links`` dicts
+   (``[needs.links.<name>]`` in ``ubproject.toml``) and can carry an
+   optional ``schema`` block for cardinality / typing constraints.
 
-      # In conf.py
-      needs_extra_links = [
-          {
-              "option": "verifies",
-              "incoming": "verified by",
-              "outgoing": "verifies",
-          },
-          {
-              "option": "implements",
-              "incoming": "implemented by",
-              "outgoing": "implements",
-          }
-      ]
+   .. code-block:: toml
+
+      # In ubproject.toml
+      [needs.links.verifies]
+      incoming = "verified by"
+      outgoing = "verifies"
+      schema.minItems = 1          # every need using :verifies: must link at least one target
+
+      [needs.links.implements]
+      incoming = "implemented by"
+      outgoing = "implements"
 
    .. fault:: Invalid link type used in a need
       :id: ER_SN_INVALID_LINK_TYPE
 
-      If a link type is not defined in the configuration, Sphinx-Needs will
-      raise an error during the build process.
+      A link option is used in a directive that is not declared in
+      ``needs_links``. Sphinx-Needs raises a warning during the build.
 
-   .. fault:: Link type value is not valid
+   .. fault:: Link target value violates link schema
       :id: ER_SN_INVALID_LINK_TYPE_VALUE
 
-      If a link type value does not match the expected format or type, Sphinx-Needs
-      will raise an error during the build process.
+      The set of targets assigned to a link field violates the declared
+      ``schema`` (e.g. ``maxItems``, ``minItems``, ``uniqueItems``),
+      leading to an ``sn_schema_violation`` warning.
 
 .. feature:: Automatic ID generation
    :id: FE_SPHINX_NEEDS_AUTO_ID
@@ -645,33 +662,103 @@ Linking and Traceability
 
    .. fault:: Dead link not detected
       :id: ER_SN_DEAD_LINK_NOT_DETECTED
-      
+
 
       If a dead link is not detected, it may lead to missing traceability
       and incorrect documentation.
 
    .. fault:: Dead link false positive
       :id: ER_SN_DEAD_LINK_FALSE_POSITIVE
-      
+
 
       If a dead link is falsely reported, it may lead to unnecessary warnings
       and confusion in the documentation.
 
+.. feature:: Conditional link evaluation (NeedLink, parse_conditions)
+   :id: FE_SN_LINK_CONDITIONS
+   :tools: TOOL_SN
+   :si: yes
+
+   Introduced with Sphinx-Needs 8.0, a link target can carry an
+   inline filter expression
+   (``:links: FEAT_X[status=="done"]``) that is evaluated during the
+   build. Conditional links are represented internally by the
+   structured ``NeedLink`` object, enabling downstream analysis of
+   *which* links are active under *which* conditions.
+
+   A link type opts in via ``parse_conditions = true`` in its
+   ``[needs.links.<name>]`` entry.
+
+   .. code-block:: toml
+
+      [needs.links.verifies]
+      incoming = "verified by"
+      outgoing = "verifies"
+      parse_conditions = true
+
+   .. code-block:: rst
+
+      .. test:: Integration test for login feature
+         :id: T_LOGIN
+         :verifies: FE_LOGIN[status=="released"]
+
+   .. fault:: Condition expression parse error
+      :id: ER_SN_LINK_COND_PARSE
+
+      The expression inside the link condition is syntactically
+      invalid or references an undefined field. Sphinx-Needs reports
+      a warning, but if the warning is ignored the link is dropped
+      from the traceability, silently reducing coverage.
+
+   .. fault:: Condition evaluates to the wrong result
+      :id: ER_SN_LINK_COND_EVAL_WRONG
+
+      The predicate references a mutable field (``status``, ``tags``)
+      whose value changes between the authoring and audit state of
+      the documentation. The evaluated link set therefore differs
+      from the one intended by the author.
+
+   .. fault:: Condition hides a safety-relevant link
+      :id: ER_SN_LINK_COND_HIDES_SAFE
+
+      A conditional filter excludes a link that should be active for
+      safety reasons (e.g. a test verifying a fault is conditioned on
+      ``status == "released"`` but the fault is already safety-
+      relevant in earlier states). Coverage reports under-represent
+      the traceability.
+
+   .. fault:: Condition opt-in missing
+      :id: ER_SN_LINK_COND_NOT_PARSED
+
+      The link type is used with an inline condition, but
+      ``parse_conditions = true`` is not set on the
+      ``[needs.links.<name>]`` entry. The bracket expression is
+      treated as part of the target ID, leading to a dead link or an
+      unintended target.
+
 Automated Features
 ++++++++++++++++++
 
-.. feature:: Constraint checking to validate need relationships
+.. feature:: Legacy constraint checking (needs_constraints)
    :id: FE_SPHINX_NEEDS_DYNAMIC_CONSTRAINTS
    :tools: TOOL_SN
    :si: yes
 
-   Define rules, or constraints, about your need data that are checked
-   during the build. For example, you can enforce that every requirement
-   must be linked to a test case.
+   .. warning::
+
+      ``needs_constraints`` is the **legacy** mechanism to validate need
+      data through Python check-code strings. Since Sphinx-Needs 7 it
+      is superseded by :need:`FE_SN_SCHEMA_VALIDATION` (JSON-Schema
+      based) which is declarative, cacheable, and auditable.
+      New classifications **should not** rely on ``needs_constraints``.
+
+   Define rules about your need data that are checked during the
+   build. For example, you can enforce that every requirement must be
+   linked to a test case.
 
    .. code-block:: python
 
-      # In conf.py
+      # Legacy form in conf.py (avoid for new projects)
       needs_constraints = {
           "req_verified": {
               "check_code": "len(links_back['verifies']) > 0",
@@ -700,7 +787,7 @@ Automated Features
 
    .. fault:: Constraint check runs with incomplete data
       :id: ER_SN_CONSTRAINT_INCOMPLETE_DATA
-      
+
 
       If a constraint check runs with incomplete data, it may lead to
       missing or incorrect traceability data and errors in the documentation.
@@ -710,6 +797,194 @@ Automated Features
 
       If a constraint check runs with invalid data, it may lead to errors in
       the documentation or incorrect traceability.
+
+.. feature:: Declarative schema validation of needs
+   :id: FE_SN_SCHEMA_VALIDATION
+   :tools: TOOL_SN
+   :si: yes
+
+   Introduced with Sphinx-Needs 7 and hardened in 8.0, schema
+   validation expresses data rules declaratively using a JSON-Schema
+   derived format. Rules are defined once, evaluated per build, and
+   produce structured diagnostics that downstream tools (ubCode,
+   ``ubc schema validate``, CI) can consume.
+
+   A schema object consists of three parts:
+
+   * ``select`` — which needs the rule applies to
+     (types, fields, combinations).
+   * ``validate.local`` — property constraints on a single need
+     (type, enum, pattern, min / max, required).
+   * ``validate.network`` — cross-need constraints along link types
+     (``contains``, ``minContains``, ``maxContains``), enabling
+     traceability completeness checks (e.g. "every safe feature must
+     have at least one test").
+   * ``severity`` — ``violation`` (build fails), ``warning`` or
+     ``info``.
+
+   Safety-critical projects (ISO 26262, IEC 61508, EN 50716) use the
+   ``violation`` severity to make an incomplete classification
+   reject the build.
+
+   .. code-block:: toml
+
+      # In ubproject.toml
+      schema_definitions_from_json = "schemas.json"
+      schema_debug_active = true
+
+   .. code-block:: json
+
+      {
+        "$defs": {
+          "type-feature": { "properties": { "type": { "const": "feature" } } },
+          "safe-feature": {
+            "allOf": [
+              { "$ref": "#/$defs/type-feature" },
+              { "properties": { "si": { "const": "yes" } },
+                "required": ["si"] }
+            ]
+          }
+        },
+        "schemas": [
+          {
+            "id": "safe-feature-has-fault",
+            "severity": "violation",
+            "message": "A safety-impacting feature must raise at least one fault",
+            "select": { "$ref": "#/$defs/safe-feature" },
+            "validate": {
+              "network": {
+                "raises": { "contains": { "local": {} }, "minContains": 1 }
+              }
+            }
+          }
+        ]
+      }
+
+   .. fault:: Schema validation silently disabled
+      :id: ER_SN_SCHEMA_DISABLED
+
+      ``needs_schema_validation_enabled`` is set to ``False`` (or
+      implicitly disabled by a configuration error) without the
+      project being aware. Safety-relevant rules are not enforced
+      during the build.
+
+   .. fault:: Schema definition itself is invalid
+      :id: ER_SN_SCHEMA_INVALID
+
+      The supplied ``needs_schema_definitions`` (or external
+      ``schema_definitions_from_json``) does not conform to the
+      JSON-Schema dialect accepted by Sphinx-Needs. Rules are not
+      evaluated and the project silently loses validation coverage.
+
+   .. fault:: Schema ``select`` does not match the intended needs
+      :id: ER_SN_SCHEMA_SELECT_WRONG
+
+      The ``select`` filter of a rule is too narrow or too broad,
+      so the rule either misses safety-relevant needs (false negative)
+      or fires on unrelated needs (false positive).
+
+   .. fault:: Schema violation not surfaced in build
+      :id: ER_SN_SCHEMA_NOT_REPORTED
+
+      A failing schema rule does not produce a user-visible warning
+      or error (e.g. because the category is listed in
+      ``suppress_warnings`` or ``-W`` is not used). The build appears
+      green although safety rules are violated.
+
+   .. fault:: Schema violation wrongly suppressed via severity
+      :id: ER_SN_SCHEMA_WRONG_SEVERITY
+
+      A rule is declared with ``severity = "info"`` or ``"warning"``
+      although it encodes a safety-relevant invariant. The violation
+      does not fail the build.
+
+   .. fault:: Network validation misses indirect links
+      :id: ER_SN_SCHEMA_NETWORK_MISS
+
+      A ``validate.network`` rule expects linkage via a specific
+      ``needs.links.<name>``, but the project uses a different link
+      option for the same semantic relation, so the check silently
+      passes with zero matches.
+
+.. feature:: Typed need fields with JSON-Schema validation
+   :id: FE_SN_TYPED_FIELDS
+   :tools: TOOL_SN
+   :si: yes
+
+   Each custom field declared via ``[needs.fields.<name>]`` can carry
+   a ``schema`` block (``type``, ``enum``, ``minimum`` / ``maximum``,
+   ``pattern``, ``format``) and a ``nullable`` flag. Value mismatches
+   are reported as ``sn_schema_violation`` warnings and written to
+   ``schema_violations.json`` in the build output.
+
+   This is the type-safe successor to the untyped string list form of
+   ``needs_extra_options``.
+
+   .. code-block:: toml
+
+      [needs.fields.asil]
+      description = "Automotive Safety Integrity Level (ISO 26262)"
+      schema.type = "string"
+      schema.enum = ["QM", "A", "B", "C", "D"]
+
+      [needs.fields.efforts]
+      description = "FTE days"
+      schema.type = "integer"
+      schema.minimum = 0
+      schema.maximum = 100
+
+   .. fault:: Schema type mismatch not detected
+      :id: ER_SN_TYPED_FIELD_TYPE_MISS
+
+      An integer-typed field receives a non-numeric value but the
+      violation is not reported (e.g. schema validation disabled or
+      category suppressed).
+
+   .. fault:: Enum constraint not enforced
+      :id: ER_SN_TYPED_FIELD_ENUM_MISS
+
+      A value outside the declared ``schema.enum`` list is accepted
+      silently, so an invalid ASIL / TCL value reaches the exported
+      ``needs.json``.
+
+   .. fault:: Range constraint not enforced
+      :id: ER_SN_TYPED_FIELD_RANGE_MISS
+
+      A value violates ``schema.minimum`` / ``schema.maximum`` but is
+      accepted. Safety metrics derived from this field are wrong.
+
+.. feature:: Typed link schemas (cardinality and targeting)
+   :id: FE_SN_TYPED_LINK_SCHEMA
+   :tools: TOOL_SN
+   :si: yes
+
+   ``[needs.links.<name>]`` supports a ``schema`` block that
+   constrains the array of link targets (``minItems``, ``maxItems``,
+   ``uniqueItems``). Combined with
+   :need:`FE_SN_SCHEMA_VALIDATION` ``validate.network`` rules this
+   expresses completeness constraints (e.g. "every fault must be
+   mitigated by at least one restriction or check").
+
+   .. code-block:: toml
+
+      [needs.links.avoids]
+      incoming = "avoided by"
+      outgoing = "avoids"
+      schema.minItems = 1
+
+   .. fault:: Link cardinality not enforced
+      :id: ER_SN_TYPED_LINK_CARD_MISS
+
+      A need uses a typed link without meeting the ``minItems`` /
+      ``maxItems`` constraint, but the violation is not reported.
+      Traceability completeness is silently broken.
+
+   .. fault:: Typed link accepts wrong target type
+      :id: ER_SN_TYPED_LINK_TARGET_WRONG
+
+      A ``validate.network`` rule on a link does not fully constrain
+      the target type, so a link intended to point at e.g. a
+      ``fault`` can target an unrelated type.
 
 Configuration & Customization
 +++++++++++++++++++++++++++++
@@ -795,6 +1070,40 @@ Exporting & Reporting
 
       If the exported needs.json file is corrupted, it may lead to errors in
       the documentation or incorrect traceability.
+
+.. feature:: Link conditions exported to needs.json
+   :id: FE_SN_JSON_LINK_CONDITIONS
+   :tools: TOOL_SN
+   :si: yes
+
+   Added in Sphinx-Needs 8.0, ``needs_json_include_link_conditions``
+   (default ``True``) controls whether link-condition expressions are
+   included in the exported outgoing link fields of ``needs.json``.
+   When enabled, downstream analysis tools (``ubc build
+   validate-json``, audit scripts) can reason about the exact set of
+   targets under each condition.
+
+   .. code-block:: toml
+
+      [needs]
+      build_json = true
+      json_include_link_conditions = true
+
+   .. fault:: Link conditions missing in needs.json
+      :id: ER_SN_JSON_LINK_COND_MISSING
+
+      ``needs_json_include_link_conditions`` is disabled, so
+      downstream tools see only the target IDs. Conditional filtering
+      is lost from the audit artefact and cannot be reproduced from
+      ``needs.json`` alone.
+
+   .. fault:: Exported link conditions differ from runtime evaluation
+      :id: ER_SN_JSON_LINK_COND_DRIFT
+
+      The exported condition string is out of sync with the
+      condition evaluated during the build (e.g. because
+      post-processing rewrote fields). The JSON artefact misrepresents
+      the state of traceability.
 
 .. feature:: Permalink generation to specific need objects
    :id: FE_SPHINX_NEEDS_EXPORT_PERMALINKS

--- a/tools/sphinx-needs/main.rst
+++ b/tools/sphinx-needs/main.rst
@@ -26,7 +26,7 @@ Analysis
 
 .. needpie:: Sphinx-Needs objects
    :legend:
-   :labels: Features, Errors, Restrictions, Checks, Steps
+   :labels: Features, Faults, Restrictions, Checks, Steps
    :explode: 0,0,0,0.1,0.1
 
    type == "feature" and "tools/sphinx-needs/" in docname
@@ -37,14 +37,14 @@ Analysis
 
 .. dropdown:: ✅ Compliance statistics
 
-   Features without errors: :need_count:`"tools/sphinx-needs/" in docname and type == "feature" and len(parent_needs_back) == 0`
+   Features without faults: :need_count:`"tools/sphinx-needs/" in docname and type == "feature" and len(parent_needs_back) == 0`
    / :need_count:`"tools/sphinx-needs/" in docname and type == "feature"`
 
-   Errors without a mitigation: :need_count:`"tools/sphinx-needs/" in docname and type == "fault" and (len(avoids_back) == 0 and len(checks_back) == 0)`
+   Faults without a mitigation: :need_count:`"tools/sphinx-needs/" in docname and type == "fault" and (len(avoids_back) == 0 and len(checks_back) == 0)`
    / :need_count:`"tools/sphinx-needs/" in docname and type == "fault"`
 
-   Restrictions without error: :need_count:`"tools/sphinx-needs/" in docname and type == "restriction" and len(avoids) == 0`
+   Restrictions without fault: :need_count:`"tools/sphinx-needs/" in docname and type == "restriction" and len(avoids) == 0`
    / :need_count:`"tools/sphinx-needs/" in docname and type == "restriction"`
 
-   Checks without error: :need_count:`"tools/sphinx-needs/" in docname and type == "check" and len(checks) == 0`
+   Checks without fault: :need_count:`"tools/sphinx-needs/" in docname and type == "check" and len(checks) == 0`
    / :need_count:`"tools/sphinx-needs/" in docname and type == "check"`

--- a/tools/sphinx-needs/main.rst
+++ b/tools/sphinx-needs/main.rst
@@ -4,7 +4,7 @@ Sphinx-Needs
 
 .. tool:: Sphinx-Needs
    :id: TOOL_SN
-   :version: 5.1.0, 4.2.0
+   :version: 8.0.0
    :status: in_progress
 
    Sphinx makes it easy to create intelligent and beautiful

--- a/tools/sphinx-needs/restrictions.rst
+++ b/tools/sphinx-needs/restrictions.rst
@@ -27,3 +27,55 @@ Restrictions
    folder shall be deleted. Then ``sphinx-build`` shall be built with the
    options ``-a`` and ``-E`` to force Sphinx to read and write really all
    files.
+
+.. restriction:: Use declarative schema validation instead of needs_constraints
+   :id: RE_SN_USE_SCHEMA
+   :avoids: ER_SN_CONSTRAINT_NOT_CHECKED, ER_SN_CONSTRAINT_FAIL_SILENTLY, ER_SN_CONSTRAINT_WRONG_DATA, ER_SN_CONSTRAINT_INCOMPLETE_DATA, ER_SN_CONSTRAINT_INVALID_DATA
+
+   The legacy ``needs_constraints`` mechanism evaluates arbitrary
+   Python expressions against need data. Safety-relevant projects
+   shall use :need:`FE_SN_SCHEMA_VALIDATION` (JSON-Schema based) via
+   ``needs_schema_definitions`` or ``schema_definitions_from_json``
+   instead. The schema form is declarative, auditable, reproducible
+   (no embedded Python), and its diagnostics are structured
+   (``sn_schema_*``), which lets CI and ubCode process them.
+
+.. restriction:: Use severity "violation" for safety-relevant schema rules
+   :id: RE_SN_SCHEMA_VIOLATION
+   :avoids: ER_SN_SCHEMA_WRONG_SEVERITY, ER_SN_SCHEMA_NOT_REPORTED
+
+   Any schema rule that encodes a safety invariant (e.g. "every safe
+   feature raises at least one fault", "every fault is mitigated")
+   shall declare ``severity = "violation"``. Combined with
+   :need:`RE_SN_WARNINGS`, a violation breaks the build and therefore
+   cannot reach a release pipeline unnoticed.
+
+.. restriction:: Type every extra field via needs.fields schema
+   :id: RE_SN_TYPE_FIELDS
+   :avoids: ER_SN_TYPED_FIELD_TYPE_MISS, ER_SN_TYPED_FIELD_ENUM_MISS, ER_SN_TYPED_FIELD_RANGE_MISS, ER_SN_INVALID_OPTION_VALUE
+
+   Every field declared under ``[needs.fields.<name>]`` shall carry
+   at least an explicit ``schema.type``. Safety-relevant enumerations
+   (``asil``, ``tcl``, ``ti``, ``td``, ``si``) shall additionally
+   declare ``schema.enum``. This removes the fall-back to an untyped
+   nullable-string schema and makes invalid values surface during
+   the build.
+
+.. restriction:: Declare cardinality on safety-relevant link types
+   :id: RE_SN_LINK_CARDINALITY
+   :avoids: ER_SN_TYPED_LINK_CARD_MISS
+
+   Link types that express safety-relevant completeness
+   (``raises``, ``avoids``, ``checks``, ``errors``, ``responsible``)
+   shall declare ``schema.minItems = 1`` under their
+   ``[needs.links.<name>]`` entry so that a missing link produces a
+   schema violation rather than a silent gap.
+
+.. restriction:: Export link conditions in needs.json
+   :id: RE_SN_JSON_LINK_COND
+   :avoids: ER_SN_JSON_LINK_COND_MISSING
+
+   ``needs_json_include_link_conditions`` shall be left at the
+   default ``True`` for the qualification artefact, so that the
+   exported ``needs.json`` is a complete record of the traceability
+   including conditions evaluated at build time.

--- a/tools/sphinx/features.rst
+++ b/tools/sphinx/features.rst
@@ -5,7 +5,7 @@ Features
 
    .. needtable::
       :filter: "tools/sphinx/" in docname and type == "feature"
-      :columns: id, title, si as "SI", parent_needs_back as "Errors"
+      :columns: id, title, si as "SI", parent_needs_back as "Faults"
 
    .. needpie:: Sphinx features
       :legend:

--- a/tools/sphinx/main.rst
+++ b/tools/sphinx/main.rst
@@ -24,7 +24,7 @@ Analysis
 
 .. needpie::
    :legend:
-   :labels: Features, Errors, Restrictions, Checks, Steps
+   :labels: Features, Faults, Restrictions, Checks, Steps
    :explode: 0,0,0,0.1,0.1
 
    type == "feature" and "tools/sphinx/" in docname
@@ -35,14 +35,14 @@ Analysis
 
 .. dropdown:: ✅ Compliance statistics
 
-   Features without errors: :need_count:`"tools/sphinx/" in docname and type == "feature" and len(parent_needs_back) == 0`
+   Features without faults: :need_count:`"tools/sphinx/" in docname and type == "feature" and len(parent_needs_back) == 0`
    / :need_count:`"tools/sphinx/" in docname and type == "feature"`
 
-   Errors without a mitigation: :need_count:`"tools/sphinx/" in docname and type == "fault" and (len(avoids_back) == 0 and len(checks_back) == 0)`
+   Faults without a mitigation: :need_count:`"tools/sphinx/" in docname and type == "fault" and (len(avoids_back) == 0 and len(checks_back) == 0)`
    / :need_count:`"tools/sphinx/" in docname and type == "fault"`
 
-   Restrictions without error: :need_count:`"Sphinx" in sections and type == "restriction" and len(avoids) == 0`
+   Restrictions without fault: :need_count:`"Sphinx" in sections and type == "restriction" and len(avoids) == 0`
    / :need_count:`"tools/sphinx/" in docname and type == "restriction"`
 
-   Checks without error: :need_count:`"Sphinx" in sections and type == "check" and len(checks) == 0`
+   Checks without fault: :need_count:`"Sphinx" in sections and type == "check" and len(checks) == 0`
    / :need_count:`"tools/sphinx/" in docname and type == "check"`

--- a/tools/ubc/features.rst
+++ b/tools/ubc/features.rst
@@ -5,7 +5,7 @@ Features
 
    .. needtable::
       :filter: "tools/ubc/" in docname and type == "feature"
-      :columns: id, title, si as "SI", parent_needs_back as "Errors"
+      :columns: id, title, si as "SI", parent_needs_back as "Faults"
 
    .. needpie:: ubc features
       :legend:

--- a/tools/ubc/features.rst
+++ b/tools/ubc/features.rst
@@ -78,3 +78,104 @@ Features
 
       Not all types and options, which are represetned in a given needs.json
       file, are known/defined by the ``ubproject.toml`` configuration.
+
+.. feature:: Validate ontology schema (``ubc schema validate``)
+   :id: FE_UBC_SCHEMA_VALIDATE
+   :tools: TOOL_UBC
+   :inputs: ART_SPHINX_RST, ART_UBC_NEEDS_JSON
+   :si: yes
+
+   Runs the same JSON-Schema-based rules that power
+   :need:`FE_SN_SCHEMA_VALIDATION` from the command line, independent
+   of a Sphinx build. This is the primary CI gate for a safety
+   qualification: the same rules that pass during ``sphinx-build``
+   are re-evaluated against the published ``needs.json`` to detect
+   drift.
+
+   .. code-block:: bash
+
+      ubc schema validate
+
+   .. fault:: Schema rules not loaded
+      :id: ER_UBC_SCHEMA_NO_RULES
+
+      ``ubc`` cannot find the schema definitions referenced by
+      ``needs_schema_definitions`` / ``schema_definitions_from_json``
+      and therefore validates against an empty rule set. Exit code is
+      ``0`` and the pipeline passes, but no safety rule is actually
+      enforced.
+
+   .. fault:: Schema rule set diverges from Sphinx-Needs
+      :id: ER_UBC_SCHEMA_DIVERGE
+
+      The version of the schema evaluation engine embedded in ``ubc``
+      differs from the one used by the installed Sphinx-Needs, so a
+      rule accepted in one tool is rejected in the other. The audit
+      artefact becomes ambiguous.
+
+   .. fault:: Safety violation reported only as warning
+      :id: ER_UBC_SCHEMA_EXIT_ZERO
+
+      ``ubc schema validate`` reports violations but returns exit
+      code ``0`` (e.g. severity configured as ``warning`` only). CI
+      does not fail and the safety breach reaches release.
+
+.. feature:: Impact analysis on git changes (``ubc diff git``)
+   :id: FE_UBC_DIFF_GIT
+   :tools: TOOL_UBC
+   :si: yes
+
+   Computes the traceability impact of a git commit / diff using the
+   classified link model. Given a configurable link depth and
+   direction, ``ubc diff git`` reports which needs are transitively
+   affected — essential for change-impact analysis required by ISO
+   26262 tool classification activities.
+
+   .. code-block:: bash
+
+      ubc diff git --depth 3 --direction both
+
+   .. fault:: Impact depth truncates the graph
+      :id: ER_UBC_DIFF_DEPTH_CUT
+
+      The configured ``--depth`` is smaller than the deepest
+      safety-relevant link chain, so the impact report misses
+      affected needs. Downstream reviewers underestimate the change.
+
+   .. fault:: Wrong direction omits incoming impact
+      :id: ER_UBC_DIFF_DIR_WRONG
+
+      ``--direction`` is set to ``outgoing`` only, so needs that
+      depend *on* a modified need (incoming links) are not reported.
+
+   .. fault:: Uncommitted local edits not covered
+      :id: ER_UBC_DIFF_DIRTY
+
+      The diff is computed against HEAD and ignores uncommitted
+      changes in the working tree, which causes the report to
+      under-represent the actual delta being reviewed.
+
+.. feature:: Generate AI-agent skill for the project (``ubc agent-skill``)
+   :id: FE_UBC_AGENT_SKILL
+   :tools: TOOL_UBC
+   :outputs: ART_UBC_NEEDS_JSON
+   :si: no
+
+   Emits a machine-readable description of the project ontology
+   (types, fields, links, schemas) that LLM-based tooling can load
+   to author and review needs deterministically. Because the skill
+   is generated from the same ``ubproject.toml`` that drives the
+   build, agent behaviour stays in sync with the qualified
+   configuration.
+
+   .. code-block:: bash
+
+      ubc agent-skill
+
+   .. fault:: Skill out of sync with qualified configuration
+      :id: ER_UBC_AGENT_SKILL_STALE
+
+      The generated skill is committed once and not refreshed when
+      ``ubproject.toml`` changes. Agents create needs that conflict
+      with the current schema and the build fails later than
+      necessary.

--- a/tools/ubc/main.rst
+++ b/tools/ubc/main.rst
@@ -27,7 +27,7 @@ Analysis
 
 .. needpie:: Sphinx-Needs objects
    :legend: 
-   :labels: Features, Errors, Restrictions, Checks, Steps
+   :labels: Features, Faults, Restrictions, Checks, Steps
    :explode: 0,0,0,0.1,0.1
 
    type == "feature" and "tools/ubc/" in docname
@@ -38,19 +38,19 @@ Analysis
 
 .. dropdown:: ✅ Compliance statistics
 
-   Features without errors:
+   Features without faults:
    :need_count:`"tools/ubc/" in docname and type == "feature" and len(parent_needs_back) == 0` /
    :need_count:`"tools/ubc/" in docname and type == "feature"`
 
-   Errors without a mitigation: 
+   Faults without a mitigation:
    :need_count:`"tools/ubc/" in docname and type == "fault" and (len(avoids_back) == 0 and len(checks_back) == 0)` /
    :need_count:`"tools/ubc/" in docname and type == "fault"`
 
-   Restrictions without error:
+   Restrictions without fault:
    :need_count:`"tools/ubc/" in docname and type == "restriction" and len(avoids) == 0` /
    :need_count:`"tools/ubc/" in docname and type == "restriction"`
 
-   Checks without error:
+   Checks without fault:
    :need_count:`"tools/ubc/" in docname and type == "check" and len(checks) == 0` /
    :need_count:`"tools/ubc/" in docname and type == "check"`
 

--- a/ubproject.toml
+++ b/ubproject.toml
@@ -39,25 +39,74 @@ transition_length = 10
 build_json = true
 
 # Additional options, which shall be available for all need types.
-# see https://sphinx-needs.readthedocs.io/en/latest/configuration.html#needs-extra-options
-extra_options = [
-    "impact",
-    "owner",
-    "probability",
-    "result",
-    "risklevel",
-    "version",
-    "ti",
-    "si",
-    "td",
-    "tcl",
-    "priority",
-    "company",
-    "department",
-    "email",
-    "url",
-    
-]
+# Migrated to the typed field form introduced with Sphinx-Needs 7+
+# see https://sphinx-needs.readthedocs.io/en/latest/configuration.html#needs-fields
+# Each [needs.fields.<name>] table defines one extra field; optional
+# ``schema`` entries enable JSON-Schema validation (types, enums, ranges).
+
+[needs.fields.impact]
+description = "Qualitative impact of a fault (e.g. low, medium, high)"
+schema.type = "string"
+
+[needs.fields.owner]
+description = "Owner or maintainer of the need"
+schema.type = "string"
+
+[needs.fields.probability]
+description = "Qualitative probability of occurrence (e.g. low, medium, high)"
+schema.type = "string"
+
+[needs.fields.result]
+description = "Evaluation result of a check or test"
+schema.type = "string"
+
+[needs.fields.risklevel]
+description = "Derived risk level from impact and probability"
+schema.type = "string"
+
+[needs.fields.version]
+description = "Version string of the classified tool or artifact"
+schema.type = "string"
+
+[needs.fields.ti]
+description = "Tool Impact (TI) according to ISO 26262-8:2018, clause 11"
+schema.type = "string"
+schema.enum = ["1", "2", "tbd"]
+
+[needs.fields.si]
+description = "Safety Impact flag (yes|no|<empty> for undetermined)"
+schema.type = "string"
+schema.enum = ["yes", "no", ""]
+
+[needs.fields.td]
+description = "Tool error Detection (TD) according to ISO 26262-8:2018, clause 11"
+schema.type = "string"
+schema.enum = ["1", "2", "3", "tbd"]
+
+[needs.fields.tcl]
+description = "Tool Confidence Level (TCL) according to ISO 26262-8:2018, clause 11"
+schema.type = "string"
+schema.enum = ["1", "2", "3", "tbd"]
+
+[needs.fields.priority]
+description = "Priority of the use case / feature"
+schema.type = "string"
+
+[needs.fields.company]
+description = "Organisation owning the classified artefact"
+schema.type = "string"
+
+[needs.fields.department]
+description = "Department within the organisation"
+schema.type = "string"
+
+[needs.fields.email]
+description = "Contact email address"
+schema.type = "string"
+
+[needs.fields.url]
+description = "External reference URL"
+schema.type = "string"
 
 # Force the author to set an ID by hand.
 # Otherwise Sphinx-Needs would create one based on the Need title.
@@ -81,47 +130,25 @@ id_regex = "[A-Z_]{3,10}(_[\\d]{1,3})*"
 # collapse = { "default" = "False" } # The meta-area of all Sphinx-Needs objects shall be hidden.
 
 # collapse-bug in Sphinx-Needs
-# [needs.global_options.collapse]
+# [needs.fields.collapse]
 # default = true
 
-[needs.global_options.style]
+# Per-type default rendering style for the built-in ``style`` field.
+# Moved from the deprecated ``needs_global_options`` to ``needs_fields``
+# (SN 7+, ``needs_global_options`` is deprecated and will be removed).
+[needs.fields.style]
+description = "Visual rendering style used by needflow / need tables"
+schema.type = "string"
 predicates = [
-  [
-    "type in ['usecase']",
-    "purple_bar",
-  ],
-  [
-    "type in ['feature']",
-    "green_bar",
-  ],
-  [
-    "type in ['error']",
-    "red_bar",
-  ],
-  [
-    "type in ['tool']",
-    "blue_bar",
-  ],
-  [
-    "type in ['check']",
-    "pink_bar",
-  ],
-  [
-    "type in ['restriction']",
-    "orange_bar",
-  ],
-  [
-    "type in ['step']",
-    "gray_bar",
-  ],
-  [
-    "type in ['artifact']",
-    "tropical_bar",
-  ],
-  [
-    "type in ['test']",
-    "black_bar",
-  ],
+  [ "type in ['usecase']",     "purple_bar"   ],
+  [ "type in ['feature']",     "green_bar"    ],
+  [ "type in ['fault']",       "red_bar"      ],
+  [ "type in ['tool']",        "blue_bar"     ],
+  [ "type in ['check']",       "pink_bar"     ],
+  [ "type in ['restriction']", "orange_bar"   ],
+  [ "type in ['step']",        "gray_bar"     ],
+  [ "type in ['artifact']",    "tropical_bar" ],
+  [ "type in ['test']",        "black_bar"    ],
 ]
 
 # List of need type used in the documentation.
@@ -203,9 +230,12 @@ prefix = "STEP_"
 color = "#777777"
 style = "rectangle"
 
-[[needs.extra_links]]
+# Link types migrated from [[needs.extra_links]] (deprecated in SN 7+)
+# to the new dict form [needs.links.<name>]
+# see https://sphinx-needs.readthedocs.io/en/latest/configuration.html#needs-links
+
+[needs.links.uses]
 # project --> usecase
-option = "uses"
 incoming = "used_by"
 outgoing = "uses"
 copy = false
@@ -214,9 +244,8 @@ style_part = "thickness=1,#00AA00"
 style_start = "-"
 style_end = "->"
 
-[[needs.extra_links]]
+[needs.links.member_of]
 # responsible --> project
-option = "member_of"
 incoming = "has_member"
 outgoing = "member_of"
 copy = false
@@ -225,9 +254,8 @@ style_part = "thickness=1,#00AA00"
 style_start = "-"
 style_end = "->"
 
-[[needs.extra_links]]
+[needs.links.inputs]
 # usecase/feature --> artifact
-option = "inputs"
 incoming = "needed by"
 outgoing = "inputs"
 copy = false
@@ -237,9 +265,8 @@ style_start = "<-"
 style_end = "-"
 style_reverse = true
 
-[[needs.extra_links]]
+[needs.links.outputs]
 # usecase/feature --> artifact
-option = "outputs"
 incoming = "provided_by"
 outgoing = "outputs"
 copy = false
@@ -248,9 +275,8 @@ style_part = "thickness=1,#0000AA"
 style_start = "-"
 style_end = "->"
 
-[[needs.extra_links]]
-# usecase/feature --> error
-option = "raises"
+[needs.links.raises]
+# usecase/feature --> fault
 incoming = "raised_by"
 outgoing = "raises"
 copy = false
@@ -259,74 +285,63 @@ style_part = "thickness=1,#FF3333"
 style_start = "-"
 style_end = "->"
 
-[[needs.extra_links]]
+[needs.links.features]
 # usecase --> feature, features --> restriction
-option = "features"
 incoming = "featured by"
 outgoing = "features"
 copy = false
 style = "#Gold"
 style_part = "#Gold"
 
-[[needs.extra_links]]
+[needs.links.tools]
 # feature -> tools
-option = "tools"
 incoming = "part of"
 outgoing = "tools"
 copy = false
 style = "#333333"
 style_part = "#333333"
 
-[[needs.extra_links]]
-option = "tool"
+[needs.links.tool]
 incoming = "contains"
 outgoing = "tool"
 copy = false
 style = "#333333"
 style_part = "#333333"
 
-[[needs.extra_links]]
+[needs.links.requires_unsafe]
 # usecase --> feature, features --> restriction
-option = "requires_unsafe"
 incoming = "unsafe required by"
 outgoing = "requires unsafe"
 copy = false
 style = "#Gold"
 style_part = "#Gold"
 
-[[needs.extra_links]]
-# restriction --> error
-option = "avoids"
+[needs.links.avoids]
+# restriction --> fault
 incoming = "avoided by"
 outgoing = "avoids"
 copy = false
 style = "#FA8072"
 style_part = "#FA8072"
 
-
-[[needs.extra_links]]
-#  check -> error, check --> restriction
-option = "checks"
+[needs.links.checks]
+#  check -> fault, check --> restriction
 incoming = "checked by"
 outgoing = "checks"
 copy = false
 style = "#FA8072"
 style_part = "#FA8072"
 
-
-[[needs.extra_links]]
-# test --> error
-option = "errors"
+[needs.links.errors]
+# test --> fault
 incoming = "tests"
 outgoing = "errors"
 copy = false
 style = "#FA8072"
 style_part = "#FA8072"
 
-
-[[needs.extra_links]]
+[needs.links.responsible]
 # usecase --> responsible
-option = "responsible"
 incoming = "responsible for"
 outgoing = "responsible"
 copy = false

--- a/usage/contribute.rst
+++ b/usage/contribute.rst
@@ -27,7 +27,7 @@ This classification documentation focuses on the blue elements:
 
 * Use cases
 * Features
-* Errors
+* Faults
 * Restrictions
 * Tools
 
@@ -82,7 +82,7 @@ are marked with a green circle.
       -TD: integer
       ..Links..
       +tools <<tool>>
-      -child needs <<error>>
+      -child needs <<fault>>
       +inputs <<artifact>>
       +outputs <<artifact>>
    }
@@ -105,7 +105,7 @@ are marked with a green circle.
       +status: string
       __Specific__
       ..Links..
-      +avoids <<error>>
+      +avoids <<fault>>
    }
 
    uc -> fe
@@ -149,12 +149,12 @@ and indicates whether the ``use case`` has a safety-relevant impact:
    that the target documentation is the single source of truth for a high
    safety critical project.
 
-The **Tool Error Detection (TD)** value must be defined for each ``error``
-and represents the ability to detect the error:
+The **Tool Error Detection (TD)** value must be defined for each ``fault``
+and represents the ability to detect the fault:
 
-- **TD = 1**: The error is detected, and execution stops without
+- **TD = 1**: The fault is detected, and execution stops without
   producing a final result.
-- **TD = 3**: The error is not detected.
+- **TD = 3**: The fault is not detected.
 - **TD = 2**: This value is not used in this document.
 
 The final **Tool Confidence Level (TCL)** is calculated as follows:
@@ -162,7 +162,7 @@ The final **Tool Confidence Level (TCL)** is calculated as follows:
 - If **TI = 1**, then **TCL = 1**, and no further actions are required
   for tool qualification.
 - If **TI = 2**, the highest **TD** value among all linked,
-  safety-relevant features and their errors determines the **TCL**.
+  safety-relevant features and their faults determines the **TCL**.
 - A **tbd** (to  be done) can be set, if the final TCL can onyl be set
   after missing features and co. are added.
 
@@ -183,7 +183,7 @@ handling during the tool qualification process.
      - Yes
    * - TD
      - 1, 3
-     - Error, Feature
+     - Fault, Feature
      - Yes
    * - TCL
      - 1, 2, 3, tbd

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -49,22 +49,22 @@ Use cases are stored in the ``/use_cases`` folder.
 
       The documentation is used as part of an official release delivery.
 
-Features & Errors
+Features & Faults
 +++++++++++++++++
 
 A feature describes a specific functionality of a tool. During its
-execution, certain errors may occur, which are documented as sub-needs
+execution, certain faults may occur, which are documented as sub-needs
 within the feature.
 
-An important attribute of both features and errors is the Tool Error
-Detection level (``TD``), which indicates how well an error can be
-detected: - **TD = 1**: The error is detected, and execution stops
-without producing a final result. - **TD = 2**: The error is reported,
-but execution continues. - **TD = 3**: The error occurs silently
+An important attribute of both features and faults is the Tool Error
+Detection level (``TD``), which indicates how well a fault can be
+detected: - **TD = 1**: The fault is detected, and execution stops
+without producing a final result. - **TD = 2**: The fault is reported,
+but execution continues. - **TD = 3**: The fault occurs silently
 without detection.
 
 The feature's ``TD`` value is determined by the "worst" TD level of
-all its related errors.
+all its related faults.
 
 Features are stored in tool-specific folders, such as ``/tools/sphinx/``.
 
@@ -80,11 +80,11 @@ Features are stored in tool-specific folders, such as ``/tools/sphinx/``.
       Read Traceability objects from rst/md files
       into the internal storage.
 
-      .. fault:: Syntax errors in rst/md files     <- A first error with title
+      .. fault:: Syntax errors in rst/md files     <- A first fault with title
          :id: ER_SN_SYN_ER                         <- Unique ID
          :td: 1                                    <- Tool Error Detection level
 
-      .. fault:: Missing external needs.json file  <- A second error with title
+      .. fault:: Missing external needs.json file  <- A second fault with title
          :id: ER_SN_JSON_NOT_FOUND                 <- Unique ID
          :td: 3                                    <- Tool Error Detection level
 
@@ -93,9 +93,9 @@ Features are stored in tool-specific folders, such as ``/tools/sphinx/``.
 Restrictions
 ++++++++++++
 
-Restrictions define ways to avoid specific errors, such as by not
+Restrictions define ways to avoid specific faults, such as by not
 using certain functions or configurations. They are linked to one or
-more errors.
+more faults.
 
 During tool execution, compliance with restrictions should be checked
 automatically or through a manual process.
@@ -106,7 +106,7 @@ automatically or through a manual process.
 
    .. restriction:: Do not use dynamic functions      <- Title
       :id: CHECK_SN_NO_DYN                            <- Unique ID
-      :avoids: ER_SN_DYN_INVALID, ER_SN_DYN_WRONG     <- Links to errors
+      :avoids: ER_SN_DYN_INVALID, ER_SN_DYN_WRONG     <- Links to faults
 
       Dynamic functions can execute unqualified code,
       which has full access to all Sphinx-Needs data.
@@ -117,10 +117,10 @@ Checks
 
 Checks are responsible for the following tasks:
 
-* Verifying if an error has occurred.
+* Verifying if a fault has occurred.
 * Ensuring that a restriction has been followed.
 
-Like restrictions, checks are linked to errors and are often
+Like restrictions, checks are linked to faults and are often
 implemented as additional scripts executed during tool execution in a
 CI system.
 

--- a/usage/qualification.rst
+++ b/usage/qualification.rst
@@ -12,7 +12,7 @@ which includes:
 
 * Additional test cases for Sphinx and Sphinx-Needs.
 * Documentation of ``checks`` and ``process steps``, including links to
-  the ``errors`` described in this document.
+  the ``faults`` described in this document.
 * A license for ``ubCode`` and its command-line tool ``ubc``, enabling
   specific checks in VS Code and CI environments.
 * A Qualification Report generator to document the final qualification

--- a/uv.lock
+++ b/uv.lock
@@ -24,28 +24,6 @@ wheels = [
 ]
 
 [[package]]
-name = "arrow"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-    { name = "tzdata" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
-]
-
-[[package]]
-name = "attrs"
-version = "25.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
-]
-
-[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -515,15 +493,6 @@ woff = [
 ]
 
 [[package]]
-name = "fqdn"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
-]
-
-[[package]]
 name = "furo"
 version = "2025.9.25"
 source = { registry = "https://pypi.org/simple" }
@@ -567,18 +536,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isoduration"
-version = "20.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "arrow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
-]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -591,51 +548,22 @@ wheels = [
 ]
 
 [[package]]
-name = "jsonpointer"
-version = "3.0.0"
+name = "jsonschema-rs"
+version = "0.37.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/52/06a843d1c21d11ae22fc15abc5cb7e3b83c8d5aa7e6056c009e7189f4a58/jsonschema_rs-0.37.4.tar.gz", hash = "sha256:67f36f1c445c70f9975d17a84ce37f79593f6234d7eb292830d7749e5fa58ff4", size = 1790550, upload-time = "2025-11-30T21:00:23.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
-]
-
-[[package]]
-name = "jsonschema"
-version = "4.25.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
-]
-
-[package.optional-dependencies]
-format = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer" },
-    { name = "rfc3339-validator" },
-    { name = "rfc3987" },
-    { name = "uri-template" },
-    { name = "webcolors" },
-]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "referencing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/fc8a5338167c45cdaf8b2ebc79e1c404c881b9cb1a0f69312acc6d38ec59/jsonschema_rs-0.37.4-cp310-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5975e448092e99d6cc60793a71f0fee516dbf0fd1e6d2f6f1e4689627268f344", size = 4448311, upload-time = "2025-11-30T21:00:05.694Z" },
+    { url = "https://files.pythonhosted.org/packages/48/17/073c55453ec65644957acfe9b435ab45e4a8208faba43fec7ceb0f92607c/jsonschema_rs-0.37.4-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1d3f8c8b376966c19fd4183fa979dbadc9fdd6070f2bfa4d127bdf70946963cc", size = 2277865, upload-time = "2025-11-30T21:00:07.915Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3e/584247d45ad6fe020d040f892316d7100affb51d7bb2b8b31dde9633b353/jsonschema_rs-0.37.4-cp310-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:393ece7037a0d19fd528f7a67a32749453876468871a0bd2267909a57d8d4e32", size = 2453442, upload-time = "2025-11-30T21:00:09.402Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/85/b3f795037abf89087f62a7e49baca82e34b4f0d576ac30a740ca61cd33ea/jsonschema_rs-0.37.4-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dedf72e5e673e3af5b9925979fd71484debada61fb7a3dfabf9bbc74b8012664", size = 2334092, upload-time = "2025-11-30T21:00:10.705Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e9/644c293e0169425e0a321be197266162d5df2718af18014444edfb185eb9/jsonschema_rs-0.37.4-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e159075b1846718466998d5a9294c661113b347b8b4749767680a97c8ed2bf4d", size = 2418813, upload-time = "2025-11-30T21:00:12.056Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4b/e65a64839d8c8f55352ff12ccf37035cfbc8f38a383ef57ba0621007fc1b/jsonschema_rs-0.37.4-cp310-abi3-win32.whl", hash = "sha256:0f17a61deb557faa57dffb9596e4f022873404f935114367788b1eebdec2bb00", size = 2007260, upload-time = "2025-11-30T21:00:13.919Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d8/d2f94cca643bd4bd70f43762c981e566b9afe16c367a2f05fe97d7c8200c/jsonschema_rs-0.37.4-cp310-abi3-win_amd64.whl", hash = "sha256:03b34f911e99343fc388651688683010daee538a3cf8cf86a7997bca28fdf16b", size = 2226699, upload-time = "2025-11-30T21:00:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/04/cd/e881e8a5aaeecb56e93d20de1b0dfbb085eba972ffba3b5793a5ebf635f0/jsonschema_rs-0.37.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:75f3b4e0707dcb3dccf911ff49e387b4db54957fe1a19d3423015a65e3762057", size = 2275657, upload-time = "2025-11-30T21:00:17.42Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b0/e5fbee8d0e32bacbf8efb372be3a1973e02856c7415c8f2af78b4332f241/jsonschema_rs-0.37.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e93a8720f6e858d872dc2882e7d3b3243ee76f7aa4d60048272773d44df466e7", size = 2415434, upload-time = "2025-11-30T21:00:19.092Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/60/2a376a86787004245b04867babb1719949a01f45dca47404c935e9e288d9/jsonschema_rs-0.37.4-pp311-pypy311_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:a56d154b638deb947dbd0dfc285c349eb23a877221f2b0496a2dfa25948cc239", size = 2331823, upload-time = "2025-11-30T21:00:20.457Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0f/9693e268eb55d13bf9624f2914a5f09b6a75ee086db554d1495074f116de/jsonschema_rs-0.37.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:10fd978a145a6f8d11373879e7d0ff232b409f77c7faf608e6b4549a7f90aaed", size = 2224657, upload-time = "2025-11-30T21:00:21.769Z" },
 ]
 
 [[package]]
@@ -877,6 +805,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/58/8f/76d5dc21ac64a49e5498d7f0472c0781dae442dd266a67458baec38288ec/matplotlib-3.10.7-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:15112bcbaef211bd663fa935ec33313b948e214454d949b723998a43357b17b0", size = 8252283, upload-time = "2025-10-09T00:27:54.739Z" },
     { url = "https://files.pythonhosted.org/packages/27/0d/9c5d4c2317feb31d819e38c9f947c942f42ebd4eb935fc6fd3518a11eaa7/matplotlib-3.10.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d2a959c640cdeecdd2ec3136e8ea0441da59bcaf58d67e9c590740addba2cb68", size = 8116733, upload-time = "2025-10-09T00:27:56.406Z" },
     { url = "https://files.pythonhosted.org/packages/9a/cc/3fe688ff1355010937713164caacf9ed443675ac48a997bab6ed23b3f7c0/matplotlib-3.10.7-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3886e47f64611046bc1db523a09dd0a0a6bed6081e6f90e13806dd1d1d1b5e91", size = 8693919, upload-time = "2025-10-09T00:27:58.41Z" },
+]
+
+[[package]]
+name = "minijinja"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/4f/c06a20fa16a63dacc131aa82cf0cbf95239cfb851fb60330c8016e9862b7/minijinja-2.19.0.tar.gz", hash = "sha256:c2e95fd56a8ab9419403ea7f25273a6b570495116bc1af21fb4c178f4d9c5ff7", size = 290703, upload-time = "2026-04-01T21:31:41.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/e8/45957b91756603f6e60241a1d3919fbdb94a5e11bd1b9570a13df1af207f/minijinja-2.19.0-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:487d2def6d16d30ad0cb7b0e949afb06815e144e502d0cf4465cd34fa429361e", size = 2098108, upload-time = "2026-04-01T21:31:25.819Z" },
+    { url = "https://files.pythonhosted.org/packages/67/89/8fd3e725297e9e1c8751f29535654b06af5770c36e7cea75ed62d4b21024/minijinja-2.19.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2725643b1d19f4f60614153bee6ea1a291c6aa410071b61299113cfca1c23e20", size = 1096108, upload-time = "2026-04-01T21:31:27.868Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/12/b48b6a2d60fe7c211773ede48bcefb1c6fe1c973509381f8a21b9841a71a/minijinja-2.19.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a59e1d23b5e62aca1c527869a0ba09126fdc9c69d43beeccb3cf07c36fc8fbe5", size = 1072471, upload-time = "2026-04-01T21:31:29.381Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/92/86d8c40ff6035ef19bf8f35b25b13fcd763c7624e3763f6b2e2ce5ccd959/minijinja-2.19.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86693fff42fdf9e6c6684b5b44e79ee708b9419e6331ffe217bbcbe7c2de6016", size = 1126643, upload-time = "2026-04-01T21:31:31.174Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ac/014e16acde50f6542877b02ff2f80e610193edc8899ee11363271e4373fb/minijinja-2.19.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cc7ef1f9dbdaa9d47c75d7f903d55cbd766c55b38ec195c0ba11e880566bbcf3", size = 1260960, upload-time = "2026-04-01T21:31:32.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d9/3d4ef6c327acd40f6efafc8d834c6bd288a7271b4b342cbac07726eba72e/minijinja-2.19.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3defd79efd5af849dd48e3ab03b67772dc30fe53935316c953f77868938da77d", size = 1272078, upload-time = "2026-04-01T21:31:33.782Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/34/d0a4f228510b3784717063f63d6784ebd4021afe77df8c868ef06e2140c2/minijinja-2.19.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c2bacdeca8ca5d30035e8e78d119faca248b5ba0597200937a56980880d7d11d", size = 1347195, upload-time = "2026-04-01T21:31:35.334Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/4b0b92360bf44a9c0ec4db57537cecb3774dead6e5bed8e88c5079541f4e/minijinja-2.19.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:38ed4fef67f550ae8552b261f3a40d389bab782f1dc19e8a015b3ad25da03bc1", size = 1425814, upload-time = "2026-04-01T21:31:36.66Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/ac1ac223755881885ccbcbdaad164a4a323606d9d0abdeedcc262d51a1d9/minijinja-2.19.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:695ce4264dbe6422ef45a344dc2c1044eb3a7543606e1b4a255df5b443074462", size = 1349051, upload-time = "2026-04-01T21:31:38.126Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/48/b78f84441a81be2cd528dcc54f8726f6e10ecb613357cfadb7479e832857/minijinja-2.19.0-cp38-abi3-win32.whl", hash = "sha256:fa11ceea225e0458ff8126de18c3baad936106cefe95ac9c9b65795bd71b018f", size = 1025114, upload-time = "2026-04-01T21:31:39.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/28/5b7eabd21a7e3b0c7f2b33d11305e6ae6fadbc022d09ed2730adae4cb479/minijinja-2.19.0-cp38-abi3-win_amd64.whl", hash = "sha256:0cf0ee1abf477c91caf8730cd19ab01960c6be124af9cd1fcbd546a4bfde36bb", size = 1078381, upload-time = "2026-04-01T21:31:40.726Z" },
 ]
 
 [[package]]
@@ -1183,20 +1130,6 @@ wheels = [
 ]
 
 [[package]]
-name = "referencing"
-version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1224,141 +1157,12 @@ wheels = [
 ]
 
 [[package]]
-name = "rfc3339-validator"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
-]
-
-[[package]]
-name = "rfc3987"
-version = "1.3.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/bb/f1395c4b62f251a1cb503ff884500ebd248eed593f41b469f89caa3547bd/rfc3987-1.3.8.tar.gz", hash = "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733", size = 20700, upload-time = "2018-07-29T17:23:47.954Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/d4/f7407c3d15d5ac779c3dd34fbbc6ea2090f77bd7dd12f207ccf881551208/rfc3987-1.3.8-py2.py3-none-any.whl", hash = "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53", size = 13377, upload-time = "2018-07-29T17:23:45.313Z" },
-]
-
-[[package]]
 name = "roman-numerals-py"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/76/48fd56d17c5bdbdf65609abbc67288728a98ed4c02919428d4f52d23b24b/roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d", size = 9017, upload-time = "2025-02-22T07:34:54.333Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/97/d2cbbaa10c9b826af0e10fdf836e1bf344d9f0abb873ebc34d1f49642d3f/roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c", size = 7742, upload-time = "2025-02-22T07:34:52.422Z" },
-]
-
-[[package]]
-name = "rpds-py"
-version = "0.28.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/dc/95f074d43452b3ef5d06276696ece4b3b5d696e7c9ad7173c54b1390cd70/rpds_py-0.28.0.tar.gz", hash = "sha256:abd4df20485a0983e2ca334a216249b6186d6e3c1627e106651943dbdb791aea", size = 27419, upload-time = "2025-10-22T22:24:29.327Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/34/058d0db5471c6be7bef82487ad5021ff8d1d1d27794be8730aad938649cf/rpds_py-0.28.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:03065002fd2e287725d95fbc69688e0c6daf6c6314ba38bdbaa3895418e09296", size = 362344, upload-time = "2025-10-22T22:21:39.713Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/67/9503f0ec8c055a0782880f300c50a2b8e5e72eb1f94dfc2053da527444dd/rpds_py-0.28.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28ea02215f262b6d078daec0b45344c89e161eab9526b0d898221d96fdda5f27", size = 348440, upload-time = "2025-10-22T22:21:41.056Z" },
-    { url = "https://files.pythonhosted.org/packages/68/2e/94223ee9b32332a41d75b6f94b37b4ce3e93878a556fc5f152cbd856a81f/rpds_py-0.28.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25dbade8fbf30bcc551cb352376c0ad64b067e4fc56f90e22ba70c3ce205988c", size = 379068, upload-time = "2025-10-22T22:21:42.593Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/25/54fd48f9f680cfc44e6a7f39a5fadf1d4a4a1fd0848076af4a43e79f998c/rpds_py-0.28.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c03002f54cc855860bfdc3442928ffdca9081e73b5b382ed0b9e8efe6e5e205", size = 390518, upload-time = "2025-10-22T22:21:43.998Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/85/ac258c9c27f2ccb1bd5d0697e53a82ebcf8088e3186d5d2bf8498ee7ed44/rpds_py-0.28.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9699fa7990368b22032baf2b2dce1f634388e4ffc03dfefaaac79f4695edc95", size = 525319, upload-time = "2025-10-22T22:21:45.645Z" },
-    { url = "https://files.pythonhosted.org/packages/40/cb/c6734774789566d46775f193964b76627cd5f42ecf246d257ce84d1912ed/rpds_py-0.28.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9b06fe1a75e05e0713f06ea0c89ecb6452210fd60e2f1b6ddc1067b990e08d9", size = 404896, upload-time = "2025-10-22T22:21:47.544Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/53/14e37ce83202c632c89b0691185dca9532288ff9d390eacae3d2ff771bae/rpds_py-0.28.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac9f83e7b326a3f9ec3ef84cda98fb0a74c7159f33e692032233046e7fd15da2", size = 382862, upload-time = "2025-10-22T22:21:49.176Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/83/f3642483ca971a54d60caa4449f9d6d4dbb56a53e0072d0deff51b38af74/rpds_py-0.28.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:0d3259ea9ad8743a75a43eb7819324cdab393263c91be86e2d1901ee65c314e0", size = 398848, upload-time = "2025-10-22T22:21:51.024Z" },
-    { url = "https://files.pythonhosted.org/packages/44/09/2d9c8b2f88e399b4cfe86efdf2935feaf0394e4f14ab30c6c5945d60af7d/rpds_py-0.28.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a7548b345f66f6695943b4ef6afe33ccd3f1b638bd9afd0f730dd255c249c9e", size = 412030, upload-time = "2025-10-22T22:21:52.665Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/f5/e1cec473d4bde6df1fd3738be8e82d64dd0600868e76e92dfeaebbc2d18f/rpds_py-0.28.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9a40040aa388b037eb39416710fbcce9443498d2eaab0b9b45ae988b53f5c67", size = 559700, upload-time = "2025-10-22T22:21:54.123Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/be/73bb241c1649edbf14e98e9e78899c2c5e52bbe47cb64811f44d2cc11808/rpds_py-0.28.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8f60c7ea34e78c199acd0d3cda37a99be2c861dd2b8cf67399784f70c9f8e57d", size = 584581, upload-time = "2025-10-22T22:21:56.102Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/9c/ffc6e9218cd1eb5c2c7dbd276c87cd10e8c2232c456b554169eb363381df/rpds_py-0.28.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1571ae4292649100d743b26d5f9c63503bb1fedf538a8f29a98dce2d5ba6b4e6", size = 549981, upload-time = "2025-10-22T22:21:58.253Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/50/da8b6d33803a94df0149345ee33e5d91ed4d25fc6517de6a25587eae4133/rpds_py-0.28.0-cp311-cp311-win32.whl", hash = "sha256:5cfa9af45e7c1140af7321fa0bef25b386ee9faa8928c80dc3a5360971a29e8c", size = 214729, upload-time = "2025-10-22T22:21:59.625Z" },
-    { url = "https://files.pythonhosted.org/packages/12/fd/b0f48c4c320ee24c8c20df8b44acffb7353991ddf688af01eef5f93d7018/rpds_py-0.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd8d86b5d29d1b74100982424ba53e56033dc47720a6de9ba0259cf81d7cecaa", size = 223977, upload-time = "2025-10-22T22:22:01.092Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/21/c8e77a2ac66e2ec4e21f18a04b4e9a0417ecf8e61b5eaeaa9360a91713b4/rpds_py-0.28.0-cp311-cp311-win_arm64.whl", hash = "sha256:4e27d3a5709cc2b3e013bf93679a849213c79ae0573f9b894b284b55e729e120", size = 217326, upload-time = "2025-10-22T22:22:02.944Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/5c/6c3936495003875fe7b14f90ea812841a08fca50ab26bd840e924097d9c8/rpds_py-0.28.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6b4f28583a4f247ff60cd7bdda83db8c3f5b05a7a82ff20dd4b078571747708f", size = 366439, upload-time = "2025-10-22T22:22:04.525Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f9/a0f1ca194c50aa29895b442771f036a25b6c41a35e4f35b1a0ea713bedae/rpds_py-0.28.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d678e91b610c29c4b3d52a2c148b641df2b4676ffe47c59f6388d58b99cdc424", size = 348170, upload-time = "2025-10-22T22:22:06.397Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ea/42d243d3a586beb72c77fa5def0487daf827210069a95f36328e869599ea/rpds_py-0.28.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e819e0e37a44a78e1383bf1970076e2ccc4dc8c2bbaa2f9bd1dc987e9afff628", size = 378838, upload-time = "2025-10-22T22:22:07.932Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/78/3de32e18a94791af8f33601402d9d4f39613136398658412a4e0b3047327/rpds_py-0.28.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5ee514e0f0523db5d3fb171f397c54875dbbd69760a414dccf9d4d7ad628b5bd", size = 393299, upload-time = "2025-10-22T22:22:09.435Z" },
-    { url = "https://files.pythonhosted.org/packages/13/7e/4bdb435afb18acea2eb8a25ad56b956f28de7c59f8a1d32827effa0d4514/rpds_py-0.28.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3fa06d27fdcee47f07a39e02862da0100cb4982508f5ead53ec533cd5fe55e", size = 518000, upload-time = "2025-10-22T22:22:11.326Z" },
-    { url = "https://files.pythonhosted.org/packages/31/d0/5f52a656875cdc60498ab035a7a0ac8f399890cc1ee73ebd567bac4e39ae/rpds_py-0.28.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:46959ef2e64f9e4a41fc89aa20dbca2b85531f9a72c21099a3360f35d10b0d5a", size = 408746, upload-time = "2025-10-22T22:22:13.143Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/cd/49ce51767b879cde77e7ad9fae164ea15dce3616fe591d9ea1df51152706/rpds_py-0.28.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8455933b4bcd6e83fde3fefc987a023389c4b13f9a58c8d23e4b3f6d13f78c84", size = 386379, upload-time = "2025-10-22T22:22:14.602Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/99/e4e1e1ee93a98f72fc450e36c0e4d99c35370220e815288e3ecd2ec36a2a/rpds_py-0.28.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ad50614a02c8c2962feebe6012b52f9802deec4263946cddea37aaf28dd25a66", size = 401280, upload-time = "2025-10-22T22:22:16.063Z" },
-    { url = "https://files.pythonhosted.org/packages/61/35/e0c6a57488392a8b319d2200d03dad2b29c0db9996f5662c3b02d0b86c02/rpds_py-0.28.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e5deca01b271492553fdb6c7fd974659dce736a15bae5dad7ab8b93555bceb28", size = 412365, upload-time = "2025-10-22T22:22:17.504Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6a/841337980ea253ec797eb084665436007a1aad0faac1ba097fb906c5f69c/rpds_py-0.28.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:735f8495a13159ce6a0d533f01e8674cec0c57038c920495f87dcb20b3ddb48a", size = 559573, upload-time = "2025-10-22T22:22:19.108Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/5e/64826ec58afd4c489731f8b00729c5f6afdb86f1df1df60bfede55d650bb/rpds_py-0.28.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:961ca621ff10d198bbe6ba4957decca61aa2a0c56695384c1d6b79bf61436df5", size = 583973, upload-time = "2025-10-22T22:22:20.768Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/ee/44d024b4843f8386a4eeaa4c171b3d31d55f7177c415545fd1a24c249b5d/rpds_py-0.28.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2374e16cc9131022e7d9a8f8d65d261d9ba55048c78f3b6e017971a4f5e6353c", size = 553800, upload-time = "2025-10-22T22:22:22.25Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/89/33e675dccff11a06d4d85dbb4d1865f878d5020cbb69b2c1e7b2d3f82562/rpds_py-0.28.0-cp312-cp312-win32.whl", hash = "sha256:d15431e334fba488b081d47f30f091e5d03c18527c325386091f31718952fe08", size = 216954, upload-time = "2025-10-22T22:22:24.105Z" },
-    { url = "https://files.pythonhosted.org/packages/af/36/45f6ebb3210887e8ee6dbf1bc710ae8400bb417ce165aaf3024b8360d999/rpds_py-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:a410542d61fc54710f750d3764380b53bf09e8c4edbf2f9141a82aa774a04f7c", size = 227844, upload-time = "2025-10-22T22:22:25.551Z" },
-    { url = "https://files.pythonhosted.org/packages/57/91/f3fb250d7e73de71080f9a221d19bd6a1c1eb0d12a1ea26513f6c1052ad6/rpds_py-0.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:1f0cfd1c69e2d14f8c892b893997fa9a60d890a0c8a603e88dca4955f26d1edd", size = 217624, upload-time = "2025-10-22T22:22:26.914Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/03/ce566d92611dfac0085c2f4b048cd53ed7c274a5c05974b882a908d540a2/rpds_py-0.28.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e9e184408a0297086f880556b6168fa927d677716f83d3472ea333b42171ee3b", size = 366235, upload-time = "2025-10-22T22:22:28.397Z" },
-    { url = "https://files.pythonhosted.org/packages/00/34/1c61da1b25592b86fd285bd7bd8422f4c9d748a7373b46126f9ae792a004/rpds_py-0.28.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:edd267266a9b0448f33dc465a97cfc5d467594b600fe28e7fa2f36450e03053a", size = 348241, upload-time = "2025-10-22T22:22:30.171Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/00/ed1e28616848c61c493a067779633ebf4b569eccaacf9ccbdc0e7cba2b9d/rpds_py-0.28.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85beb8b3f45e4e32f6802fb6cd6b17f615ef6c6a52f265371fb916fae02814aa", size = 378079, upload-time = "2025-10-22T22:22:31.644Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b2/ccb30333a16a470091b6e50289adb4d3ec656fd9951ba8c5e3aaa0746a67/rpds_py-0.28.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d2412be8d00a1b895f8ad827cc2116455196e20ed994bb704bf138fe91a42724", size = 393151, upload-time = "2025-10-22T22:22:33.453Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d0/73e2217c3ee486d555cb84920597480627d8c0240ff3062005c6cc47773e/rpds_py-0.28.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cf128350d384b777da0e68796afdcebc2e9f63f0e9f242217754e647f6d32491", size = 517520, upload-time = "2025-10-22T22:22:34.949Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/91/23efe81c700427d0841a4ae7ea23e305654381831e6029499fe80be8a071/rpds_py-0.28.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a2036d09b363aa36695d1cc1a97b36865597f4478470b0697b5ee9403f4fe399", size = 408699, upload-time = "2025-10-22T22:22:36.584Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ee/a324d3198da151820a326c1f988caaa4f37fc27955148a76fff7a2d787a9/rpds_py-0.28.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8e1e9be4fa6305a16be628959188e4fd5cd6f1b0e724d63c6d8b2a8adf74ea6", size = 385720, upload-time = "2025-10-22T22:22:38.014Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ad/e68120dc05af8b7cab4a789fccd8cdcf0fe7e6581461038cc5c164cd97d2/rpds_py-0.28.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0a403460c9dd91a7f23fc3188de6d8977f1d9603a351d5db6cf20aaea95b538d", size = 401096, upload-time = "2025-10-22T22:22:39.869Z" },
-    { url = "https://files.pythonhosted.org/packages/99/90/c1e070620042459d60df6356b666bb1f62198a89d68881816a7ed121595a/rpds_py-0.28.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d7366b6553cdc805abcc512b849a519167db8f5e5c3472010cd1228b224265cb", size = 411465, upload-time = "2025-10-22T22:22:41.395Z" },
-    { url = "https://files.pythonhosted.org/packages/68/61/7c195b30d57f1b8d5970f600efee72a4fad79ec829057972e13a0370fd24/rpds_py-0.28.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5b43c6a3726efd50f18d8120ec0551241c38785b68952d240c45ea553912ac41", size = 558832, upload-time = "2025-10-22T22:22:42.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3d/06f3a718864773f69941d4deccdf18e5e47dd298b4628062f004c10f3b34/rpds_py-0.28.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0cb7203c7bc69d7c1585ebb33a2e6074492d2fc21ad28a7b9d40457ac2a51ab7", size = 583230, upload-time = "2025-10-22T22:22:44.877Z" },
-    { url = "https://files.pythonhosted.org/packages/66/df/62fc783781a121e77fee9a21ead0a926f1b652280a33f5956a5e7833ed30/rpds_py-0.28.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a52a5169c664dfb495882adc75c304ae1d50df552fbd68e100fdc719dee4ff9", size = 553268, upload-time = "2025-10-22T22:22:46.441Z" },
-    { url = "https://files.pythonhosted.org/packages/84/85/d34366e335140a4837902d3dea89b51f087bd6a63c993ebdff59e93ee61d/rpds_py-0.28.0-cp313-cp313-win32.whl", hash = "sha256:2e42456917b6687215b3e606ab46aa6bca040c77af7df9a08a6dcfe8a4d10ca5", size = 217100, upload-time = "2025-10-22T22:22:48.342Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/1c/f25a3f3752ad7601476e3eff395fe075e0f7813fbb9862bd67c82440e880/rpds_py-0.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:e0a0311caedc8069d68fc2bf4c9019b58a2d5ce3cd7cb656c845f1615b577e1e", size = 227759, upload-time = "2025-10-22T22:22:50.219Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d6/5f39b42b99615b5bc2f36ab90423ea404830bdfee1c706820943e9a645eb/rpds_py-0.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:04c1b207ab8b581108801528d59ad80aa83bb170b35b0ddffb29c20e411acdc1", size = 217326, upload-time = "2025-10-22T22:22:51.647Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/8b/0c69b72d1cee20a63db534be0df271effe715ef6c744fdf1ff23bb2b0b1c/rpds_py-0.28.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f296ea3054e11fc58ad42e850e8b75c62d9a93a9f981ad04b2e5ae7d2186ff9c", size = 355736, upload-time = "2025-10-22T22:22:53.211Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/6d/0c2ee773cfb55c31a8514d2cece856dd299170a49babd50dcffb15ddc749/rpds_py-0.28.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5a7306c19b19005ad98468fcefeb7100b19c79fc23a5f24a12e06d91181193fa", size = 342677, upload-time = "2025-10-22T22:22:54.723Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/1c/22513ab25a27ea205144414724743e305e8153e6abe81833b5e678650f5a/rpds_py-0.28.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5d9b86aa501fed9862a443c5c3116f6ead8bc9296185f369277c42542bd646b", size = 371847, upload-time = "2025-10-22T22:22:56.295Z" },
-    { url = "https://files.pythonhosted.org/packages/60/07/68e6ccdb4b05115ffe61d31afc94adef1833d3a72f76c9632d4d90d67954/rpds_py-0.28.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e5bbc701eff140ba0e872691d573b3d5d30059ea26e5785acba9132d10c8c31d", size = 381800, upload-time = "2025-10-22T22:22:57.808Z" },
-    { url = "https://files.pythonhosted.org/packages/73/bf/6d6d15df80781d7f9f368e7c1a00caf764436518c4877fb28b029c4624af/rpds_py-0.28.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a5690671cd672a45aa8616d7374fdf334a1b9c04a0cac3c854b1136e92374fe", size = 518827, upload-time = "2025-10-22T22:22:59.826Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d3/2decbb2976cc452cbf12a2b0aaac5f1b9dc5dd9d1f7e2509a3ee00421249/rpds_py-0.28.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9f1d92ecea4fa12f978a367c32a5375a1982834649cdb96539dcdc12e609ab1a", size = 399471, upload-time = "2025-10-22T22:23:01.968Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/2c/f30892f9e54bd02e5faca3f6a26d6933c51055e67d54818af90abed9748e/rpds_py-0.28.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d252db6b1a78d0a3928b6190156042d54c93660ce4d98290d7b16b5296fb7cc", size = 377578, upload-time = "2025-10-22T22:23:03.52Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/5d/3bce97e5534157318f29ac06bf2d279dae2674ec12f7cb9c12739cee64d8/rpds_py-0.28.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:d61b355c3275acb825f8777d6c4505f42b5007e357af500939d4a35b19177259", size = 390482, upload-time = "2025-10-22T22:23:05.391Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f0/886bd515ed457b5bd93b166175edb80a0b21a210c10e993392127f1e3931/rpds_py-0.28.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:acbe5e8b1026c0c580d0321c8aae4b0a1e1676861d48d6e8c6586625055b606a", size = 402447, upload-time = "2025-10-22T22:23:06.93Z" },
-    { url = "https://files.pythonhosted.org/packages/42/b5/71e8777ac55e6af1f4f1c05b47542a1eaa6c33c1cf0d300dca6a1c6e159a/rpds_py-0.28.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:8aa23b6f0fc59b85b4c7d89ba2965af274346f738e8d9fc2455763602e62fd5f", size = 552385, upload-time = "2025-10-22T22:23:08.557Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/cb/6ca2d70cbda5a8e36605e7788c4aa3bea7c17d71d213465a5a675079b98d/rpds_py-0.28.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7b14b0c680286958817c22d76fcbca4800ddacef6f678f3a7c79a1fe7067fe37", size = 575642, upload-time = "2025-10-22T22:23:10.348Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d4/407ad9960ca7856d7b25c96dcbe019270b5ffdd83a561787bc682c797086/rpds_py-0.28.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:bcf1d210dfee61a6c86551d67ee1031899c0fdbae88b2d44a569995d43797712", size = 544507, upload-time = "2025-10-22T22:23:12.434Z" },
-    { url = "https://files.pythonhosted.org/packages/51/31/2f46fe0efcac23fbf5797c6b6b7e1c76f7d60773e525cb65fcbc582ee0f2/rpds_py-0.28.0-cp313-cp313t-win32.whl", hash = "sha256:3aa4dc0fdab4a7029ac63959a3ccf4ed605fee048ba67ce89ca3168da34a1342", size = 205376, upload-time = "2025-10-22T22:23:13.979Z" },
-    { url = "https://files.pythonhosted.org/packages/92/e4/15947bda33cbedfc134490a41841ab8870a72a867a03d4969d886f6594a2/rpds_py-0.28.0-cp313-cp313t-win_amd64.whl", hash = "sha256:7b7d9d83c942855e4fdcfa75d4f96f6b9e272d42fffcb72cd4bb2577db2e2907", size = 215907, upload-time = "2025-10-22T22:23:15.5Z" },
-    { url = "https://files.pythonhosted.org/packages/08/47/ffe8cd7a6a02833b10623bf765fbb57ce977e9a4318ca0e8cf97e9c3d2b3/rpds_py-0.28.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:dcdcb890b3ada98a03f9f2bb108489cdc7580176cb73b4f2d789e9a1dac1d472", size = 353830, upload-time = "2025-10-22T22:23:17.03Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/9f/890f36cbd83a58491d0d91ae0db1702639edb33fb48eeb356f80ecc6b000/rpds_py-0.28.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f274f56a926ba2dc02976ca5b11c32855cbd5925534e57cfe1fda64e04d1add2", size = 341819, upload-time = "2025-10-22T22:23:18.57Z" },
-    { url = "https://files.pythonhosted.org/packages/09/e3/921eb109f682aa24fb76207698fbbcf9418738f35a40c21652c29053f23d/rpds_py-0.28.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fe0438ac4a29a520ea94c8c7f1754cdd8feb1bc490dfda1bfd990072363d527", size = 373127, upload-time = "2025-10-22T22:23:20.216Z" },
-    { url = "https://files.pythonhosted.org/packages/23/13/bce4384d9f8f4989f1a9599c71b7a2d877462e5fd7175e1f69b398f729f4/rpds_py-0.28.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8a358a32dd3ae50e933347889b6af9a1bdf207ba5d1a3f34e1a38cd3540e6733", size = 382767, upload-time = "2025-10-22T22:23:21.787Z" },
-    { url = "https://files.pythonhosted.org/packages/23/e1/579512b2d89a77c64ccef5a0bc46a6ef7f72ae0cf03d4b26dcd52e57ee0a/rpds_py-0.28.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e80848a71c78aa328fefaba9c244d588a342c8e03bda518447b624ea64d1ff56", size = 517585, upload-time = "2025-10-22T22:23:23.699Z" },
-    { url = "https://files.pythonhosted.org/packages/62/3c/ca704b8d324a2591b0b0adcfcaadf9c862375b11f2f667ac03c61b4fd0a6/rpds_py-0.28.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f586db2e209d54fe177e58e0bc4946bea5fb0102f150b1b2f13de03e1f0976f8", size = 399828, upload-time = "2025-10-22T22:23:25.713Z" },
-    { url = "https://files.pythonhosted.org/packages/da/37/e84283b9e897e3adc46b4c88bb3f6ec92a43bd4d2f7ef5b13459963b2e9c/rpds_py-0.28.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ae8ee156d6b586e4292491e885d41483136ab994e719a13458055bec14cf370", size = 375509, upload-time = "2025-10-22T22:23:27.32Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c2/a980beab869d86258bf76ec42dec778ba98151f253a952b02fe36d72b29c/rpds_py-0.28.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a805e9b3973f7e27f7cab63a6b4f61d90f2e5557cff73b6e97cd5b8540276d3d", size = 392014, upload-time = "2025-10-22T22:23:29.332Z" },
-    { url = "https://files.pythonhosted.org/packages/da/b5/b1d3c5f9d3fa5aeef74265f9c64de3c34a0d6d5cd3c81c8b17d5c8f10ed4/rpds_py-0.28.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5d3fd16b6dc89c73a4da0b4ac8b12a7ecc75b2864b95c9e5afed8003cb50a728", size = 402410, upload-time = "2025-10-22T22:23:31.14Z" },
-    { url = "https://files.pythonhosted.org/packages/74/ae/cab05ff08dfcc052afc73dcb38cbc765ffc86f94e966f3924cd17492293c/rpds_py-0.28.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6796079e5d24fdaba6d49bda28e2c47347e89834678f2bc2c1b4fc1489c0fb01", size = 553593, upload-time = "2025-10-22T22:23:32.834Z" },
-    { url = "https://files.pythonhosted.org/packages/70/80/50d5706ea2a9bfc9e9c5f401d91879e7c790c619969369800cde202da214/rpds_py-0.28.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:76500820c2af232435cbe215e3324c75b950a027134e044423f59f5b9a1ba515", size = 576925, upload-time = "2025-10-22T22:23:34.47Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/12/85a57d7a5855a3b188d024b099fd09c90db55d32a03626d0ed16352413ff/rpds_py-0.28.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bbdc5640900a7dbf9dd707fe6388972f5bbd883633eb68b76591044cfe346f7e", size = 542444, upload-time = "2025-10-22T22:23:36.093Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/65/10643fb50179509150eb94d558e8837c57ca8b9adc04bd07b98e57b48f8c/rpds_py-0.28.0-cp314-cp314-win32.whl", hash = "sha256:adc8aa88486857d2b35d75f0640b949759f79dc105f50aa2c27816b2e0dd749f", size = 207968, upload-time = "2025-10-22T22:23:37.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/84/0c11fe4d9aaea784ff4652499e365963222481ac647bcd0251c88af646eb/rpds_py-0.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:66e6fa8e075b58946e76a78e69e1a124a21d9a48a5b4766d15ba5b06869d1fa1", size = 218876, upload-time = "2025-10-22T22:23:39.179Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e0/3ab3b86ded7bb18478392dc3e835f7b754cd446f62f3fc96f4fe2aca78f6/rpds_py-0.28.0-cp314-cp314-win_arm64.whl", hash = "sha256:a6fe887c2c5c59413353b7c0caff25d0e566623501ccfff88957fa438a69377d", size = 212506, upload-time = "2025-10-22T22:23:40.755Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ec/d5681bb425226c3501eab50fc30e9d275de20c131869322c8a1729c7b61c/rpds_py-0.28.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7a69df082db13c7070f7b8b1f155fa9e687f1d6aefb7b0e3f7231653b79a067b", size = 355433, upload-time = "2025-10-22T22:23:42.259Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ec/568c5e689e1cfb1ea8b875cffea3649260955f677fdd7ddc6176902d04cd/rpds_py-0.28.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b1cde22f2c30ebb049a9e74c5374994157b9b70a16147d332f89c99c5960737a", size = 342601, upload-time = "2025-10-22T22:23:44.372Z" },
-    { url = "https://files.pythonhosted.org/packages/32/fe/51ada84d1d2a1d9d8f2c902cfddd0133b4a5eb543196ab5161d1c07ed2ad/rpds_py-0.28.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5338742f6ba7a51012ea470bd4dc600a8c713c0c72adaa0977a1b1f4327d6592", size = 372039, upload-time = "2025-10-22T22:23:46.025Z" },
-    { url = "https://files.pythonhosted.org/packages/07/c1/60144a2f2620abade1a78e0d91b298ac2d9b91bc08864493fa00451ef06e/rpds_py-0.28.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e1460ebde1bcf6d496d80b191d854adedcc619f84ff17dc1c6d550f58c9efbba", size = 382407, upload-time = "2025-10-22T22:23:48.098Z" },
-    { url = "https://files.pythonhosted.org/packages/45/ed/091a7bbdcf4038a60a461df50bc4c82a7ed6d5d5e27649aab61771c17585/rpds_py-0.28.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e3eb248f2feba84c692579257a043a7699e28a77d86c77b032c1d9fbb3f0219c", size = 518172, upload-time = "2025-10-22T22:23:50.16Z" },
-    { url = "https://files.pythonhosted.org/packages/54/dd/02cc90c2fd9c2ef8016fd7813bfacd1c3a1325633ec8f244c47b449fc868/rpds_py-0.28.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3bbba5def70b16cd1c1d7255666aad3b290fbf8d0fe7f9f91abafb73611a91", size = 399020, upload-time = "2025-10-22T22:23:51.81Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/81/5d98cc0329bbb911ccecd0b9e19fbf7f3a5de8094b4cda5e71013b2dd77e/rpds_py-0.28.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3114f4db69ac5a1f32e7e4d1cbbe7c8f9cf8217f78e6e002cedf2d54c2a548ed", size = 377451, upload-time = "2025-10-22T22:23:53.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/07/4d5bcd49e3dfed2d38e2dcb49ab6615f2ceb9f89f5a372c46dbdebb4e028/rpds_py-0.28.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4b0cb8a906b1a0196b863d460c0222fb8ad0f34041568da5620f9799b83ccf0b", size = 390355, upload-time = "2025-10-22T22:23:55.299Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/79/9f14ba9010fee74e4f40bf578735cfcbb91d2e642ffd1abe429bb0b96364/rpds_py-0.28.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cf681ac76a60b667106141e11a92a3330890257e6f559ca995fbb5265160b56e", size = 403146, upload-time = "2025-10-22T22:23:56.929Z" },
-    { url = "https://files.pythonhosted.org/packages/39/4c/f08283a82ac141331a83a40652830edd3a4a92c34e07e2bbe00baaea2f5f/rpds_py-0.28.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1e8ee6413cfc677ce8898d9cde18cc3a60fc2ba756b0dec5b71eb6eb21c49fa1", size = 552656, upload-time = "2025-10-22T22:23:58.62Z" },
-    { url = "https://files.pythonhosted.org/packages/61/47/d922fc0666f0dd8e40c33990d055f4cc6ecff6f502c2d01569dbed830f9b/rpds_py-0.28.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b3072b16904d0b5572a15eb9d31c1954e0d3227a585fc1351aa9878729099d6c", size = 576782, upload-time = "2025-10-22T22:24:00.312Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/0c/5bafdd8ccf6aa9d3bfc630cfece457ff5b581af24f46a9f3590f790e3df2/rpds_py-0.28.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b670c30fd87a6aec281c3c9896d3bae4b205fd75d79d06dc87c2503717e46092", size = 544671, upload-time = "2025-10-22T22:24:02.297Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/37/dcc5d8397caa924988693519069d0beea077a866128719351a4ad95e82fc/rpds_py-0.28.0-cp314-cp314t-win32.whl", hash = "sha256:8014045a15b4d2b3476f0a287fcc93d4f823472d7d1308d47884ecac9e612be3", size = 205749, upload-time = "2025-10-22T22:24:03.848Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/69/64d43b21a10d72b45939a28961216baeb721cc2a430f5f7c3bfa21659a53/rpds_py-0.28.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7a4e59c90d9c27c561eb3160323634a9ff50b04e4f7820600a2beb0ac90db578", size = 216233, upload-time = "2025-10-22T22:24:05.471Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/bc/b43f2ea505f28119bd551ae75f70be0c803d2dbcd37c1b3734909e40620b/rpds_py-0.28.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f5e7101145427087e493b9c9b959da68d357c28c562792300dd21a095118ed16", size = 363913, upload-time = "2025-10-22T22:24:07.129Z" },
-    { url = "https://files.pythonhosted.org/packages/28/f2/db318195d324c89a2c57dc5195058cbadd71b20d220685c5bd1da79ee7fe/rpds_py-0.28.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:31eb671150b9c62409a888850aaa8e6533635704fe2b78335f9aaf7ff81eec4d", size = 350452, upload-time = "2025-10-22T22:24:08.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f2/1391c819b8573a4898cedd6b6c5ec5bc370ce59e5d6bdcebe3c9c1db4588/rpds_py-0.28.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48b55c1f64482f7d8bd39942f376bfdf2f6aec637ee8c805b5041e14eeb771db", size = 380957, upload-time = "2025-10-22T22:24:10.826Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/5c/e5de68ee7eb7248fce93269833d1b329a196d736aefb1a7481d1e99d1222/rpds_py-0.28.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24743a7b372e9a76171f6b69c01aedf927e8ac3e16c474d9fe20d552a8cb45c7", size = 391919, upload-time = "2025-10-22T22:24:12.559Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/4f/2376336112cbfeb122fd435d608ad8d5041b3aed176f85a3cb32c262eb80/rpds_py-0.28.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:389c29045ee8bbb1627ea190b4976a310a295559eaf9f1464a1a6f2bf84dde78", size = 528541, upload-time = "2025-10-22T22:24:14.197Z" },
-    { url = "https://files.pythonhosted.org/packages/68/53/5ae232e795853dd20da7225c5dd13a09c0a905b1a655e92bdf8d78a99fd9/rpds_py-0.28.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23690b5827e643150cf7b49569679ec13fe9a610a15949ed48b85eb7f98f34ec", size = 405629, upload-time = "2025-10-22T22:24:16.001Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/2d/351a3b852b683ca9b6b8b38ed9efb2347596973849ba6c3a0e99877c10aa/rpds_py-0.28.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f0c9266c26580e7243ad0d72fc3e01d6b33866cfab5084a6da7576bcf1c4f72", size = 384123, upload-time = "2025-10-22T22:24:17.585Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/15/870804daa00202728cc91cb8e2385fa9f1f4eb49857c49cfce89e304eae6/rpds_py-0.28.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:4c6c4db5d73d179746951486df97fd25e92396be07fc29ee8ff9a8f5afbdfb27", size = 400923, upload-time = "2025-10-22T22:24:19.512Z" },
-    { url = "https://files.pythonhosted.org/packages/53/25/3706b83c125fa2a0bccceac951de3f76631f6bd0ee4d02a0ed780712ef1b/rpds_py-0.28.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a3b695a8fa799dd2cfdb4804b37096c5f6dba1ac7f48a7fbf6d0485bcd060316", size = 413767, upload-time = "2025-10-22T22:24:21.316Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/f9/ce43dbe62767432273ed2584cef71fef8411bddfb64125d4c19128015018/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:6aa1bfce3f83baf00d9c5fcdbba93a3ab79958b4c7d7d1f55e7fe68c20e63912", size = 561530, upload-time = "2025-10-22T22:24:22.958Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c9/ffe77999ed8f81e30713dd38fd9ecaa161f28ec48bb80fa1cd9118399c27/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:7b0f9dceb221792b3ee6acb5438eb1f02b0cb2c247796a72b016dcc92c6de829", size = 585453, upload-time = "2025-10-22T22:24:24.779Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/d2/4a73b18821fd4669762c855fd1f4e80ceb66fb72d71162d14da58444a763/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5d0145edba8abd3db0ab22b5300c99dc152f5c9021fab861be0f0544dc3cbc5f", size = 552199, upload-time = "2025-10-22T22:24:26.54Z" },
 ]
 
 [[package]]
@@ -1473,21 +1277,21 @@ wheels = [
 
 [[package]]
 name = "sphinx-needs"
-version = "6.1.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", extra = ["format"] },
+    { name = "jsonschema-rs" },
+    { name = "minijinja" },
     { name = "requests" },
     { name = "requests-file" },
     { name = "sphinx" },
     { name = "sphinx-data-viewer" },
     { name = "sphinxcontrib-jquery" },
-    { name = "typeguard" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/8d/2066cf72cc30d00b7ade16d97f51203c33052f13bb3a43f2a49cd5713f1f/sphinx_needs-6.1.0.tar.gz", hash = "sha256:2c689302888e62919d80bef07c02c95c524f90402e61507e19162def990f3368", size = 27585352, upload-time = "2025-10-31T12:44:22.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/77/909f87ae766363e8a0bb3907f54af4a7a963538a7cdc7fe6d331e7098ed1/sphinx_needs-8.0.0.tar.gz", hash = "sha256:c4336ee0e3c949eff9eb11a14910f7b6b68cb8284d731cfddf97694037337674", size = 27638117, upload-time = "2026-03-19T13:24:09.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/4d/e7e889433c47959eeed47db4a333cb027c38e580b1ce36ac004be518ad19/sphinx_needs-6.1.0-py3-none-any.whl", hash = "sha256:0a78c5d64b1ffaed1ff2413c20bb3241937152f5d583fe7deb0dbd1730c37d55", size = 2678822, upload-time = "2025-10-31T12:44:18.925Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/dd/69c5d151e1b4d98e85371fdf8ce2c1fe497f4345f32e0429cec20442d4de/sphinx_needs-8.0.0-py3-none-any.whl", hash = "sha256:540c380c074d4088a557ea353e91513bfc1cb7712b10925c13ac9e5ebb7be091", size = 2700123, upload-time = "2026-03-19T13:24:07.37Z" },
 ]
 
 [package.optional-dependencies]
@@ -1511,9 +1315,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "furo", specifier = ">=2024.8.6" },
-    { name = "sphinx", extras = ["test"], specifier = ">=8.2.3" },
+    { name = "sphinx", extras = ["test"], specifier = ">=8.2.3,<10" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
-    { name = "sphinx-needs", extras = ["plotting"], specifier = ">=6.1.0" },
+    { name = "sphinx-needs", extras = ["plotting"], specifier = ">=8.0.0,<9" },
     { name = "sphinx-simplepdf", specifier = ">=1.6.0" },
     { name = "sphinxcontrib-plantuml", specifier = ">=0.30" },
 ]
@@ -1633,42 +1437,12 @@ wheels = [
 ]
 
 [[package]]
-name = "typeguard"
-version = "4.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/68/71c1a15b5f65f40e91b65da23b8224dad41349894535a97f63a52e462196/typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74", size = 75203, upload-time = "2025-06-18T09:56:07.624Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/a9/e3aee762739c1d7528da1c3e06d518503f8b6c439c35549b53735ba52ead/typeguard-4.4.4-py3-none-any.whl", hash = "sha256:b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e", size = 34874, upload-time = "2025-06-18T09:56:05.999Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "tzdata"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
-]
-
-[[package]]
-name = "uri-template"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
 ]
 
 [[package]]
@@ -1697,15 +1471,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/99/480b5430b7eb0916e7d5df1bee7d9508b28b48fee28da894d0a050e0e930/weasyprint-66.0.tar.gz", hash = "sha256:da71dc87dc129ac9cffdc65e5477e90365ab9dbae45c744014ec1d06303dde40", size = 504224, upload-time = "2025-07-24T11:44:42.771Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/d1/c5d9b341bf3d556c1e4c6566b3efdda0b1bb175510aa7b09dd3eee246923/weasyprint-66.0-py3-none-any.whl", hash = "sha256:82b0783b726fcd318e2c977dcdddca76515b30044bc7a830cc4fbe717582a6d0", size = 301965, upload-time = "2025-07-24T11:44:40.968Z" },
-]
-
-[[package]]
-name = "webcolors"
-version = "25.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Upgrade** `sphinx-needs` to **8.x** (`>=8.0.0,<9`) and migrate `ubproject.toml` off the deprecated SN 6.x config forms (`extra_options` list → `[needs.fields.*]`, `[[needs.extra_links]]` → `[needs.links.*]`, `[needs.global_options.style]` → `[needs.fields.style]`).
- **Extend the safety classification** with the new SN 8.x capabilities: JSON-Schema-based schema validation, typed fields, typed link schemas, conditional links (`NeedLink`/`parse_conditions`), and link-condition export via `needs_json_include_link_conditions`.
- **Extend the ubc classification** with the new CLI features relevant to ISO 26262 tool qualification: `ubc schema validate`, `ubc diff git`, `ubc agent-skill`.

## Toolchain changes

| File | Change |
|---|---|
| `pyproject.toml` | `sphinx-needs[plotting]>=8.0.0,<9`, `sphinx[test]>=8.2.3,<10` |
| `uv.lock` | Resolved SN 8.0.0, `jsonschema-rs`, `minijinja` |
| `ubproject.toml` | 14 `[needs.fields.*]`, 13 `[needs.links.*]`; safety-enums on `ti` / `si` / `td` / `tcl` |
| `tools/sphinx-needs/main.rst` | `TOOL_SN` version → `8.0.0` |

## New classification items (13)

**Features** (tools/sphinx-needs + tools/ubc)

- `FE_SN_SCHEMA_VALIDATION` — declarative `needs_schema_definitions` (local + network rules, ``violation`` severity).
- `FE_SN_TYPED_FIELDS` — typed `[needs.fields.*]` with JSON-Schema constraints.
- `FE_SN_TYPED_LINK_SCHEMA` — cardinality (`minItems` / `maxItems`) on `[needs.links.*]`.
- `FE_SN_LINK_CONDITIONS` — SN 8.0 `NeedLink` / `parse_conditions`.
- `FE_SN_JSON_LINK_CONDITIONS` — SN 8.0 `needs_json_include_link_conditions`.
- `FE_UBC_SCHEMA_VALIDATE` — `ubc schema validate` CI gate.
- `FE_UBC_DIFF_GIT` — `ubc diff git` change-impact analysis.
- `FE_UBC_AGENT_SKILL` — `ubc agent-skill` ontology export for LLM tooling.

Each new feature carries 3–6 nested `fault`s covering the safety-relevant failure modes (silent skip, wrong severity, missing coverage, drift, etc.).

**Restrictions** avoiding the new faults

- `RE_SN_USE_SCHEMA` (legacy `needs_constraints` is disallowed)
- `RE_SN_SCHEMA_VIOLATION` (`severity = \"violation\"` for safety invariants)
- `RE_SN_TYPE_FIELDS` (explicit `schema.type` on every field)
- `RE_SN_LINK_CARDINALITY` (`schema.minItems` on `raises`/`avoids`/`checks`/`errors`/`responsible`)
- `RE_SN_JSON_LINK_COND` (keep `needs_json_include_link_conditions` at default `True`)

Updated examples of `FE_SPHINX_NEEDS_CUSTOMIZABLE_OPTIONS` / `_LINKS` to the TOML form and marked `FE_SPHINX_NEEDS_DYNAMIC_CONSTRAINTS` as legacy with a cross-reference.

## Verification

- `uv sync` installs `sphinx-needs==8.0.0`.
- `sphinx-build -W -a -E -b html` **succeeds clean** (0 warnings).
- Exported `needs.json` contains **284 needs** (was 271); spot-check confirmed all 13 new IDs are present.

## Test plan

- [ ] Reviewer pulls branch, runs `uv sync && sphinx-build -W -a -E -b html . _build/html` locally and confirms a clean build.
- [ ] Spot-check the new features / faults / restrictions render correctly in `_build/html/tools/sphinx-needs/features.html`, `.../restrictions.html`, `_build/html/tools/ubc/features.html`.
- [ ] Confirm the needflow / needtable on `analysis/index` and `tools/sphinx-needs/main` still render.
- [ ] Confirm the migrated link / field tables in `ubproject.toml` still drive the visible meta-data in existing needs (e.g. style predicates still color-code types).

## Follow-ups (not in this PR)

- Author an actual `schemas.json` with ISO 26262 safety rules and wire it via `schema_definitions_from_json`.
- Add `[scripts]` entries for `ubc schema validate` / `ubc build needs` / `ubc agent-skill`.
- Classify more of the recent ubCode (VS Code extension) features under `TOOL_UBCODE`, which is currently a stub.